### PR TITLE
Fixed attempting to index nil value for Classic Era (when class doesn…

### DIFF
--- a/GSE/API/Statics.lua
+++ b/GSE/API/Statics.lua
@@ -159,6 +159,9 @@ local function determineClassName(specID)
     local specname
     if GSE.GameMode == 1 then
         local ClassTable = C_CreatureInfo.GetClassInfo(specID)
+        if ClassTable == nil then
+            return nil
+        end
         return ClassTable["className"]
     else
         specname = GetClassInfo(specID)


### PR DESCRIPTION
Fixed attempting to index nil value for Classic Era (when class doesn't exist, C_CreatureInfo.GetClassInfo returns a nil)