### PR TITLE
#1930 Skin selection dropdown (Native/Modern/addon) + relocate GUI helpers to GSE_Utils

### DIFF
--- a/GSE/API/InitialOptions.lua
+++ b/GSE/API/InitialOptions.lua
@@ -5,14 +5,6 @@ if type(GSE.DebugProfile) == "function" then GSE.DebugProfile("End Patrons") end
 
 local MODERN_CUSTOM_COLOR_DEFAULT = {r = 0.00, g = 0.44, b = 0.87}
 
-local function ClampColorComponent(value, fallback)
-    value = tonumber(value)
-    if value == nil then value = fallback or 1 end
-    if value < 0 then return 0 end
-    if value > 1 then return 1 end
-    return value
-end
-
 function GSE.resetMacroResetModifiers()
     GSEOptions.MacroResetModifiers = {}
     GSEOptions.MacroResetModifiers["LeftButton"] = false
@@ -136,7 +128,9 @@ function GSE.SetDefaultOptions()
         sequenceeditor = {height = 800, width = 800, treeWidth = 165}
     }
     GSEOptions.SyncWoWMacros = false
-    GSEOptions.UseModernSkin = false
+    -- Skin selection: GSEOptions.SkinMode ("NATIVE"/"MODERN"/"ADDON"); the
+    -- default is AUTO, represented by leaving it unset (nil). See the migration
+    -- below and GSE_Utils/Appearance.lua:GSE.GetEffectiveSkinMode.
     GSEOptions.UseModernClassColors = false
     GSEOptions.UseModernCustomColor = false
     GSEOptions.ModernCustomColor = {
@@ -181,8 +175,18 @@ if not GSE.Developer then
     end
 end
 
-if GSEOptions.UseModernSkin == nil then
-    GSEOptions.UseModernSkin = GSEOptions.UseElvUISkin == true
+-- Skin selection migration. The old boolean GSEOptions.UseModernSkin (and the
+-- even older GSEOptions.UseElvUISkin before it) is superseded by the tri-state
+-- GSEOptions.SkinMode ("NATIVE" / "MODERN" / "ADDON"; nil = AUTO = installed UI
+-- addon skin if present, else native). Resolution lives in
+-- GSE_Utils/Appearance.lua:GSE.GetEffectiveSkinMode.
+if GSEOptions.SkinMode == nil then
+    if GSEOptions.UseModernSkin == true then
+        -- Preserve users who had explicitly enabled the Modern skin.
+        GSEOptions.SkinMode = "MODERN"
+    end
+    -- UseModernSkin false/nil (and the legacy UseElvUISkin path) leaves SkinMode
+    -- nil = AUTO, which keeps "installed provider wins if present" behaviour.
 end
 
 if GSEOptions.UseModernClassColors == nil then
@@ -205,235 +209,16 @@ if type(GSEOptions.ModernCustomColor) ~= "table" then
     }
 end
 
-function GSE.ShouldUseModernSkin()
-    return GSEOptions and GSEOptions.UseModernSkin == true
-end
-
-function GSE.ShouldUseModernClassColors()
-    return GSEOptions and GSEOptions.UseModernClassColors == true and GSEOptions.UseModernCustomColor ~= true
-end
-
-function GSE.ShouldUseModernCustomColor()
-    return GSEOptions and GSEOptions.UseModernCustomColor == true
-end
-
-function GSE.GetModernCustomColor(alpha)
-    local color = GSEOptions and GSEOptions.ModernCustomColor or MODERN_CUSTOM_COLOR_DEFAULT
-    local r = ClampColorComponent(color.r or color[1], MODERN_CUSTOM_COLOR_DEFAULT.r)
-    local g = ClampColorComponent(color.g or color[2], MODERN_CUSTOM_COLOR_DEFAULT.g)
-    local b = ClampColorComponent(color.b or color[3], MODERN_CUSTOM_COLOR_DEFAULT.b)
-    local a = alpha or ClampColorComponent(color.a or color[4], 1)
-    return {r, g, b, a}
-end
-
-function GSE.SetModernCustomColor(r, g, b)
-    if not GSEOptions then GSEOptions = {} end
-    GSEOptions.ModernCustomColor = {
-        r = ClampColorComponent(r, MODERN_CUSTOM_COLOR_DEFAULT.r),
-        g = ClampColorComponent(g, MODERN_CUSTOM_COLOR_DEFAULT.g),
-        b = ClampColorComponent(b, MODERN_CUSTOM_COLOR_DEFAULT.b)
-    }
-end
-
-function GSE.ShouldUseElvUISkin()
-    return GSE.ShouldUseModernSkin()
-end
-
-local GSE_UI_SCALE_MIN = 0.50
-local GSE_UI_SCALE_MAX = 2.00
-local GSE_WINDOW_SCALE_MIN = 0.75
-local GSE_WINDOW_SCALE_MAX = 1.50
-local GSE_UI_SCALE_DEFAULT = 1.00
-local GSE_UI_SCALE_ROUNDING = 100
-local GSE_UI_SCREEN_BUFFER = 4
-
-local function ClampUIScale(value)
-    value = tonumber(value) or GSE_UI_SCALE_DEFAULT
-    if value < GSE_UI_SCALE_MIN then value = GSE_UI_SCALE_MIN end
-    if value > GSE_UI_SCALE_MAX then value = GSE_UI_SCALE_MAX end
-    return math.floor((value * GSE_UI_SCALE_ROUNDING) + 0.5) / GSE_UI_SCALE_ROUNDING
-end
-
-local function ClampWindowScale(value)
-    value = tonumber(value) or GSE_UI_SCALE_DEFAULT
-    if value < GSE_WINDOW_SCALE_MIN then value = GSE_WINDOW_SCALE_MIN end
-    if value > GSE_WINDOW_SCALE_MAX then value = GSE_WINDOW_SCALE_MAX end
-    return math.floor((value * GSE_UI_SCALE_ROUNDING) + 0.5) / GSE_UI_SCALE_ROUNDING
-end
-
-local function GetUIParentRect()
-    if not UIParent then return 0, 0, 0, 0 end
-
-    local parentLeft, parentBottom, parentWidth, parentHeight = UIParent:GetRect()
-    if parentLeft and parentBottom and parentWidth and parentHeight then
-        return parentLeft, parentBottom, parentWidth, parentHeight
-    end
-
-    return 0, 0, UIParent.GetWidth and UIParent:GetWidth() or 0, UIParent.GetHeight and UIParent:GetHeight() or 0
-end
-
-local function GetFrameScreenPoint(frame, point)
-    if not (frame and frame.GetRect) then return nil end
-
-    local left, bottom, width, height = frame:GetRect()
-    if not (left and bottom and width and height) then return nil end
-
-    point = point or "CENTER"
-    if point == "TOPLEFT" then return left, bottom + height end
-    if point == "TOPRIGHT" then return left + width, bottom + height end
-    if point == "BOTTOMLEFT" then return left, bottom end
-    if point == "BOTTOMRIGHT" then return left + width, bottom end
-    if point == "TOP" then return left + (width / 2), bottom + height end
-    if point == "BOTTOM" then return left + (width / 2), bottom end
-    if point == "LEFT" then return left, bottom + (height / 2) end
-    if point == "RIGHT" then return left + width, bottom + (height / 2) end
-    return left + (width / 2), bottom + (height / 2)
-end
-
-function GSE.SetFrameScreenPoint(frame, point, screenX, screenY)
-    if not (frame and frame.SetPoint and frame.ClearAllPoints and UIParent and screenX and screenY) then return end
-
-    point = point or "CENTER"
-    local parentScale = UIParent.GetEffectiveScale and UIParent:GetEffectiveScale() or 1
-    local frameScale = frame.GetEffectiveScale and frame:GetEffectiveScale() or parentScale
-    local scaleRatio = parentScale > 0 and frameScale / parentScale or 1
-    if not scaleRatio or scaleRatio <= 0 then scaleRatio = 1 end
-
-    local offsetX, offsetY = screenX, screenY
-    for _ = 1, 4 do
-        frame:ClearAllPoints()
-        frame:SetPoint(point, UIParent, "BOTTOMLEFT", offsetX, offsetY)
-
-        local actualX, actualY = GetFrameScreenPoint(frame, point)
-        if not actualX or not actualY then return end
-
-        local dx, dy = screenX - actualX, screenY - actualY
-        if math.abs(dx) < 0.5 and math.abs(dy) < 0.5 then return end
-
-        offsetX = offsetX + (dx / scaleRatio)
-        offsetY = offsetY + (dy / scaleRatio)
-    end
-end
-
-function GSE.GetUIScale()
-    return ClampWindowScale(GSE_C and GSE_C.UIScale)
-end
-
-function GSE.SetUIScale(value)
-    if not GSE_C then GSE_C = {} end
-    GSE_C.UIScale = ClampWindowScale(value)
-    if GSE.ApplyUIScale then GSE.ApplyUIScale() end
-end
-
-function GSE.GetMenuUIScale()
-    if not GSE_C then return GSE_UI_SCALE_DEFAULT end
-    if GSE_C.MenuUIScale == nil then
-        GSE_C.MenuUIScale = ClampUIScale(GSE_C.UIScale)
-    end
-    return ClampUIScale(GSE_C.MenuUIScale)
-end
-
-function GSE.SetMenuUIScale(value)
-    if not GSE_C then GSE_C = {} end
-    if GSE_C.MenuUIScale == nil then
-        GSE_C.MenuUIScale = ClampUIScale(GSE_C.UIScale)
-    end
-    GSE_C.MenuUIScale = ClampUIScale(value)
-    if GSE.ApplyMenuUIScale then GSE.ApplyMenuUIScale() end
-end
-
-GSE.UIScaleFrames = GSE.UIScaleFrames or setmetatable({}, {__mode = "k"})
-GSE.MenuUIScaleFrames = GSE.MenuUIScaleFrames or setmetatable({}, {__mode = "k"})
-
-function GSE.ClampFrameToScreen(frame)
-    if not (frame and frame.GetRect and frame.SetPoint and frame.ClearAllPoints and UIParent) then return end
-
-    local parentLeft, parentBottom, parentWidth, parentHeight = GetUIParentRect()
-
-    local left, bottom, width, height = frame:GetRect()
-    if not (left and bottom and width and height and parentWidth > 0 and parentHeight > 0) then return end
-
-    local minLeft = parentLeft + GSE_UI_SCREEN_BUFFER
-    local minBottom = parentBottom + GSE_UI_SCREEN_BUFFER
-    local maxLeft = parentLeft + parentWidth - width - GSE_UI_SCREEN_BUFFER
-    local maxBottom = parentBottom + parentHeight - height - GSE_UI_SCREEN_BUFFER
-    local clampedLeft = width > (parentWidth - (GSE_UI_SCREEN_BUFFER * 2)) and
-        (parentLeft + ((parentWidth - width) / 2)) or
-        math.min(math.max(left, minLeft), maxLeft)
-    local clampedBottom = height > (parentHeight - (GSE_UI_SCREEN_BUFFER * 2)) and
-        (parentBottom + ((parentHeight - height) / 2)) or
-        math.min(math.max(bottom, minBottom), maxBottom)
-
-    if math.abs(clampedLeft - left) < 0.5 and math.abs(clampedBottom - bottom) < 0.5 then return end
-
-    GSE.SetFrameScreenPoint(frame, "BOTTOMLEFT", clampedLeft, clampedBottom)
-end
-
-function GSE.ApplyScaleToFrame(frame, scale)
-    if not (frame and frame.SetScale) then return end
-
-    scale = ClampUIScale(scale or GSE.GetUIScale())
-    local preserveCenter = frame.IsShown and frame:IsShown() and frame.GetCenter and frame.ClearAllPoints and frame.SetPoint
-        and not frame.GSESkipScaleRecenter
-    local centerX, centerY
-    if preserveCenter then
-        centerX, centerY = frame:GetCenter()
-        preserveCenter = centerX and centerY and UIParent
-    end
-
-    frame:SetScale(scale)
-
-    if preserveCenter then
-        GSE.SetFrameScreenPoint(frame, "CENTER", centerX, centerY)
-        GSE.ClampFrameToScreen(frame)
-    end
-end
-
-function GSE.ApplyMenuScaleToFrame(frame)
-    if not (frame and frame.SetScale) then return end
-    GSE.ApplyScaleToFrame(frame, GSE.GetMenuUIScale())
-end
-
-function GSE.RegisterUIScaleFrame(frame)
-    if not frame then return end
-    GSE.UIScaleFrames = GSE.UIScaleFrames or setmetatable({}, {__mode = "k"})
-    GSE.UIScaleFrames[frame] = true
-    GSE.ApplyScaleToFrame(frame)
-end
-
-function GSE.RegisterMenuUIScaleFrame(frame)
-    if not frame then return end
-    GSE.MenuUIScaleFrames = GSE.MenuUIScaleFrames or setmetatable({}, {__mode = "k"})
-    GSE.MenuUIScaleFrames[frame] = true
-    GSE.ApplyMenuScaleToFrame(frame)
-end
-
-function GSE.ApplyUIScale()
-    if GSE.UIScaleFrames then
-        for frame in pairs(GSE.UIScaleFrames) do
-            if frame and frame.SetScale then
-                GSE.ApplyScaleToFrame(frame)
-            else
-                GSE.UIScaleFrames[frame] = nil
-            end
-        end
-    end
-end
-
-function GSE.ApplyMenuUIScale()
-    if GSE.MenuUIScaleFrames then
-        for frame in pairs(GSE.MenuUIScaleFrames) do
-            if frame and frame.SetScale then
-                GSE.ApplyMenuScaleToFrame(frame)
-            else
-                GSE.MenuUIScaleFrames[frame] = nil
-            end
-        end
-    end
-    if GSE.MenuFrame then
-        GSE.ApplyMenuScaleToFrame(GSE.MenuFrame)
-    end
-end
+-- NOTE: The skin accessors (GSE.ShouldUseModernSkin / ShouldUseModernClassColors
+-- / ShouldUseModernCustomColor / GetModernCustomColor / SetModernCustomColor /
+-- ShouldUseElvUISkin) and the entire UI-scale + frame-positioning subsystem
+-- (GSE.GetUIScale / SetUIScale / GetMenuUIScale / SetMenuUIScale /
+-- ApplyScaleToFrame / ApplyMenuScaleToFrame / RegisterUIScaleFrame /
+-- RegisterMenuUIScaleFrame / ApplyUIScale / ApplyMenuUIScale /
+-- SetFrameScreenPoint / ClampFrameToScreen) used to live here. They are
+-- front-end only -- the macro engine never calls them -- so they now live in
+-- GSE_Utils/Appearance.lua, the lowest shared front-end addon. Core retains only
+-- the saved-variable defaults + migration above.
 
 -- Migrate editor dimensions from old flat keys to frameLocations.sequenceeditor.
 do

--- a/GSE_GUI/Skin.lua
+++ b/GSE_GUI/Skin.lua
@@ -393,8 +393,21 @@ end
 -- ─── Provider selection ────────────────────────────────────────────────
 -- ElvUI takes priority because its skinning surface is far more complete
 -- than the EllesmereUI replicate-and-paint path.
+--
+-- The external provider only drives GSE's look when the user's effective skin
+-- mode is "ADDON" (the AUTO default when a provider is installed, or an explicit
+-- pick). When the user has explicitly chosen "NATIVE" or "MODERN", we install
+-- the no-op provider so an installed ElvUI/EllesmereUI is ignored and GSE paints
+-- its own native/modern look. GSE.GetEffectiveSkinMode lives in
+-- GSE_Utils/Appearance.lua (GSE_GUI depends on GSE_Utils, so it is available).
 local function selectProvider()
-    local provider = makeElvUIProvider() or makeEllesmereUIProvider() or makeNoopProvider()
+    local effectiveMode = GSE.GetEffectiveSkinMode and GSE.GetEffectiveSkinMode() or "NATIVE"
+    local provider
+    if effectiveMode == "ADDON" then
+        provider = makeElvUIProvider() or makeEllesmereUIProvider() or makeNoopProvider()
+    else
+        provider = makeNoopProvider()
+    end
     for k, v in pairs(provider) do GSE.Skin[k] = v end
     GSE.Skin.providerName = provider.name
 end

--- a/GSE_Options/Options.lua
+++ b/GSE_Options/Options.lua
@@ -1360,42 +1360,52 @@ local function AddAppearanceOptions(optionsCategory)
         local layout = SettingsPanel:GetLayout(optionsCategory)
         layout:AddInitializer(Settings.CreateElementInitializer("SettingsListSectionHeaderTemplate", {["name"] = "Skin", ["tooltip"] = "Skin"}))
     end
-    -- Native Skin
+    -- Skin selection dropdown.
+    --
+    -- Replaces the old Native/Modern mutually-exclusive checkbox pair. Backed by
+    -- the tri-state GSEOptions.SkinMode ("NATIVE" / "MODERN" / "ADDON"); unset =
+    -- AUTO = installed UI addon skin if present, else Native. The third entry is
+    -- only offered when ElvUI or EllesmereUI is installed and is labelled with
+    -- that addon's own name (there is no literal "Auto" entry shown to the user).
+    -- Resolution + provider gating live in GSE_Utils/Appearance.lua and
+    -- GSE_GUI/Skin.lua. A full skin change applies on /reload, as before; only
+    -- the menu logo hot-swaps here.
     do
         local function GetValue()
-            return GSEOptions.UseModernSkin ~= true
+            local m = GSEOptions and GSEOptions.SkinMode
+            if m == "NATIVE" or m == "MODERN" then return m end
+            if m == "ADDON" and GSE.GetInstalledSkinProviderName and GSE.GetInstalledSkinProviderName() then
+                return "ADDON"
+            end
+            -- AUTO (or a pinned ADDON whose provider is no longer installed):
+            -- surface the effective default so the dropdown shows a real entry.
+            if GSE.GetInstalledSkinProviderName and GSE.GetInstalledSkinProviderName() then
+                return "ADDON"
+            end
+            return "NATIVE"
         end
         local function SetValue(val)
-            GSEOptions.UseModernSkin = val ~= true
-            RefreshExclusiveOptionRows("skin")
+            GSEOptions.SkinMode = val
+            -- Keep the legacy boolean in sync for downgrade safety (older GSE
+            -- builds still read GSEOptions.UseModernSkin).
+            GSEOptions.UseModernSkin = (val == "MODERN")
             -- Live-swap the menu logo so it picks up the new skin without /reload.
             if GSE.GUI and GSE.GUI.RefreshMenuLogo then GSE.GUI.RefreshMenuLogo() end
         end
-        local setting = Settings.RegisterProxySetting(optionsCategory, "charUseClassicSkin", Settings.VarType.Boolean, "Native Skin", true, GetValue, SetValue)
-        MarkExclusiveCheckboxInitializer(
-            Settings.CreateCheckbox(optionsCategory, setting, "Use GSE's Native interface skin."),
-            "skin",
-            GetValue
-        )
-    end
-
-    -- Modern Skin
-    do
-        local function GetValue()
-            return GSEOptions.UseModernSkin == true
+        local setting = Settings.RegisterProxySetting(optionsCategory, "charSkinMode", Settings.VarType.String, "Skin", "NATIVE", GetValue, SetValue)
+        local function GetOptions()
+            local container = Settings.CreateControlTextContainer()
+            container:Add("NATIVE", L["Native"] or "Native")
+            container:Add("MODERN", L["Modern"] or "Modern")
+            local addon = GSE.GetInstalledSkinProviderName and GSE.GetInstalledSkinProviderName()
+            if addon then
+                -- Dynamic label: shows "ElvUI" or "EllesmereUI". Only present
+                -- when that addon is actually installed.
+                container:Add("ADDON", addon)
+            end
+            return container:GetData()
         end
-        local function SetValue(val)
-            GSEOptions.UseModernSkin = val == true
-            RefreshExclusiveOptionRows("skin")
-            -- Live-swap the menu logo so it picks up the new skin without /reload.
-            if GSE.GUI and GSE.GUI.RefreshMenuLogo then GSE.GUI.RefreshMenuLogo() end
-        end
-        local setting = Settings.RegisterProxySetting(optionsCategory, "charUseModernSkin", Settings.VarType.Boolean, "Modern Skin", false, GetValue, SetValue)
-        MarkExclusiveCheckboxInitializer(
-            Settings.CreateCheckbox(optionsCategory, setting, L["Use GSE's Modern interface skin. This does not require ElvUI."]),
-            "skin",
-            GetValue
-        )
+        Settings.CreateDropdown(optionsCategory, setting, GetOptions, L["Native uses GSE's own interface. Modern uses GSE's dark skin and does not require ElvUI. The third option, shown only when ElvUI or EllesmereUI is installed, matches that addon's look."])
     end
 
     do

--- a/GSE_Utils/Appearance.lua
+++ b/GSE_Utils/Appearance.lua
@@ -1,0 +1,317 @@
+local _, ns = ...
+ns.deferred = ns.deferred or {}
+
+-- =========================================================================
+-- GSE front-end appearance helpers.
+--
+-- These used to live in GSE/API/InitialOptions.lua (core GSE), but the macro
+-- engine never calls any of them -- every consumer is a front-end addon
+-- (GSE_GUI, GSE_Options, and GSE_Utils/Tracker). They are gathered here in
+-- GSE_Utils because that is the lowest shared front-end dependency:
+-- GSE_Options -> GSE_Utils and GSE_GUI -> GSE + GSE_Utils, so every caller can
+-- reach them, whereas GSE_GUI is LoadOnDemand and may never load.
+--
+-- Two concerns live together here:
+--   1. Skin selection -- which interface skin GSE should paint (Native, the
+--      built-in Modern dark skin, or an installed UI addon's skin: ElvUI /
+--      EllesmereUI). See GSE.GetEffectiveSkinMode below for the resolution.
+--   2. UI scaling + frame positioning -- the per-window / menu scale sliders
+--      and the absolute-pixel reposition math the editor, debugger and
+--      tracker windows use.
+-- =========================================================================
+
+local function setup()
+local GSE = ns.GSE
+
+-- ─── Skin selection ────────────────────────────────────────────────────
+--
+-- GSEOptions.SkinMode is a tri-state string: "NATIVE", "MODERN", "ADDON".
+-- Unset (nil) means AUTO -- the default -- which resolves to the installed
+-- UI addon's skin when one is present, otherwise Native. An explicit value
+-- is always obeyed (so picking Native gives a true native look even with
+-- ElvUI installed). Modern is never an auto value; it only applies when the
+-- user explicitly selects it.
+--
+-- The saved-variable default + migration from the old boolean
+-- GSEOptions.UseModernSkin lives in GSE/API/InitialOptions.lua (core owns
+-- GSEOptions normalisation). This file only reads the resolved value.
+
+local MODERN_CUSTOM_COLOR_DEFAULT = {r = 0.00, g = 0.44, b = 0.87}
+
+-- Local copy of core's clamp (GSE/API/InitialOptions.lua) so GetModernCustomColor
+-- does not have to widen core's public surface for one small helper.
+local function ClampColorComponent(value, fallback)
+    value = tonumber(value)
+    if value == nil then value = fallback or 1 end
+    if value < 0 then return 0 end
+    if value > 1 then return 1 end
+    return value
+end
+
+--- Returns the name of the installed external skin provider as GSE labels it
+--- ("ElvUI" or "EllesmereUI"), or nil when neither is present. ElvUI takes
+--- priority, mirroring GSE_GUI/Skin.lua's provider selection. Used both to
+--- resolve the AUTO default and to label / show the addon entry in the Skin
+--- dropdown (GSE_Options).
+function GSE.GetInstalledSkinProviderName()
+    if type(_G.ElvUI) == "table" and type(_G.ElvUI[1]) == "table" then
+        return "ElvUI"
+    end
+    if GSE.IsEllesmereUILoaded and GSE.IsEllesmereUILoaded() then
+        return "EllesmereUI"
+    end
+    return nil
+end
+
+--- Resolves GSEOptions.SkinMode to one of "NATIVE" / "MODERN" / "ADDON".
+--- An explicit stored value is returned verbatim; nil (AUTO) becomes "ADDON"
+--- when a provider is installed, else "NATIVE".
+function GSE.GetEffectiveSkinMode()
+    local mode = GSEOptions and GSEOptions.SkinMode
+    if mode == "NATIVE" or mode == "MODERN" or mode == "ADDON" then
+        return mode
+    end
+    return GSE.GetInstalledSkinProviderName() and "ADDON" or "NATIVE"
+end
+
+--- True only when the user has explicitly chosen the Modern skin. Modern is
+--- never the auto default, so this is simply SkinMode == "MODERN". Provider
+--- gating in GSE_GUI/Skin.lua guarantees no external provider is active in
+--- this case, so the Modern painters in GSE_GUI/NativeUI.lua run.
+function GSE.ShouldUseModernSkin()
+    return GSEOptions and GSEOptions.SkinMode == "MODERN"
+end
+
+function GSE.ShouldUseModernClassColors()
+    return GSEOptions and GSEOptions.UseModernClassColors == true and GSEOptions.UseModernCustomColor ~= true
+end
+
+function GSE.ShouldUseModernCustomColor()
+    return GSEOptions and GSEOptions.UseModernCustomColor == true
+end
+
+function GSE.GetModernCustomColor(alpha)
+    local color = GSEOptions and GSEOptions.ModernCustomColor or MODERN_CUSTOM_COLOR_DEFAULT
+    local r = ClampColorComponent(color.r or color[1], MODERN_CUSTOM_COLOR_DEFAULT.r)
+    local g = ClampColorComponent(color.g or color[2], MODERN_CUSTOM_COLOR_DEFAULT.g)
+    local b = ClampColorComponent(color.b or color[3], MODERN_CUSTOM_COLOR_DEFAULT.b)
+    local a = alpha or ClampColorComponent(color.a or color[4], 1)
+    return {r, g, b, a}
+end
+
+function GSE.SetModernCustomColor(r, g, b)
+    if not GSEOptions then GSEOptions = {} end
+    GSEOptions.ModernCustomColor = {
+        r = ClampColorComponent(r, MODERN_CUSTOM_COLOR_DEFAULT.r),
+        g = ClampColorComponent(g, MODERN_CUSTOM_COLOR_DEFAULT.g),
+        b = ClampColorComponent(b, MODERN_CUSTOM_COLOR_DEFAULT.b)
+    }
+end
+
+-- Backward-compatibility alias. Older GSE_GUI paths fall back to this when
+-- GSE.ShouldUseModernSkin is unavailable; the modern skin is the in-house
+-- successor to the old ElvUI skin, so it maps straight through.
+function GSE.ShouldUseElvUISkin()
+    return GSE.ShouldUseModernSkin()
+end
+
+-- ─── UI scaling + frame positioning ────────────────────────────────────
+
+local GSE_UI_SCALE_MIN = 0.50
+local GSE_UI_SCALE_MAX = 2.00
+local GSE_WINDOW_SCALE_MIN = 0.75
+local GSE_WINDOW_SCALE_MAX = 1.50
+local GSE_UI_SCALE_DEFAULT = 1.00
+local GSE_UI_SCALE_ROUNDING = 100
+local GSE_UI_SCREEN_BUFFER = 4
+
+local function ClampUIScale(value)
+    value = tonumber(value) or GSE_UI_SCALE_DEFAULT
+    if value < GSE_UI_SCALE_MIN then value = GSE_UI_SCALE_MIN end
+    if value > GSE_UI_SCALE_MAX then value = GSE_UI_SCALE_MAX end
+    return math.floor((value * GSE_UI_SCALE_ROUNDING) + 0.5) / GSE_UI_SCALE_ROUNDING
+end
+
+local function ClampWindowScale(value)
+    value = tonumber(value) or GSE_UI_SCALE_DEFAULT
+    if value < GSE_WINDOW_SCALE_MIN then value = GSE_WINDOW_SCALE_MIN end
+    if value > GSE_WINDOW_SCALE_MAX then value = GSE_WINDOW_SCALE_MAX end
+    return math.floor((value * GSE_UI_SCALE_ROUNDING) + 0.5) / GSE_UI_SCALE_ROUNDING
+end
+
+local function GetUIParentRect()
+    if not UIParent then return 0, 0, 0, 0 end
+
+    local parentLeft, parentBottom, parentWidth, parentHeight = UIParent:GetRect()
+    if parentLeft and parentBottom and parentWidth and parentHeight then
+        return parentLeft, parentBottom, parentWidth, parentHeight
+    end
+
+    return 0, 0, UIParent.GetWidth and UIParent:GetWidth() or 0, UIParent.GetHeight and UIParent:GetHeight() or 0
+end
+
+local function GetFrameScreenPoint(frame, point)
+    if not (frame and frame.GetRect) then return nil end
+
+    local left, bottom, width, height = frame:GetRect()
+    if not (left and bottom and width and height) then return nil end
+
+    point = point or "CENTER"
+    if point == "TOPLEFT" then return left, bottom + height end
+    if point == "TOPRIGHT" then return left + width, bottom + height end
+    if point == "BOTTOMLEFT" then return left, bottom end
+    if point == "BOTTOMRIGHT" then return left + width, bottom end
+    if point == "TOP" then return left + (width / 2), bottom + height end
+    if point == "BOTTOM" then return left + (width / 2), bottom end
+    if point == "LEFT" then return left, bottom + (height / 2) end
+    if point == "RIGHT" then return left + width, bottom + (height / 2) end
+    return left + (width / 2), bottom + (height / 2)
+end
+
+function GSE.SetFrameScreenPoint(frame, point, screenX, screenY)
+    if not (frame and frame.SetPoint and frame.ClearAllPoints and UIParent and screenX and screenY) then return end
+
+    point = point or "CENTER"
+    local parentScale = UIParent.GetEffectiveScale and UIParent:GetEffectiveScale() or 1
+    local frameScale = frame.GetEffectiveScale and frame:GetEffectiveScale() or parentScale
+    local scaleRatio = parentScale > 0 and frameScale / parentScale or 1
+    if not scaleRatio or scaleRatio <= 0 then scaleRatio = 1 end
+
+    local offsetX, offsetY = screenX, screenY
+    for _ = 1, 4 do
+        frame:ClearAllPoints()
+        frame:SetPoint(point, UIParent, "BOTTOMLEFT", offsetX, offsetY)
+
+        local actualX, actualY = GetFrameScreenPoint(frame, point)
+        if not actualX or not actualY then return end
+
+        local dx, dy = screenX - actualX, screenY - actualY
+        if math.abs(dx) < 0.5 and math.abs(dy) < 0.5 then return end
+
+        offsetX = offsetX + (dx / scaleRatio)
+        offsetY = offsetY + (dy / scaleRatio)
+    end
+end
+
+function GSE.GetUIScale()
+    return ClampWindowScale(GSE_C and GSE_C.UIScale)
+end
+
+function GSE.SetUIScale(value)
+    if not GSE_C then GSE_C = {} end
+    GSE_C.UIScale = ClampWindowScale(value)
+    if GSE.ApplyUIScale then GSE.ApplyUIScale() end
+end
+
+function GSE.GetMenuUIScale()
+    if not GSE_C then return GSE_UI_SCALE_DEFAULT end
+    if GSE_C.MenuUIScale == nil then
+        GSE_C.MenuUIScale = ClampUIScale(GSE_C.UIScale)
+    end
+    return ClampUIScale(GSE_C.MenuUIScale)
+end
+
+function GSE.SetMenuUIScale(value)
+    if not GSE_C then GSE_C = {} end
+    if GSE_C.MenuUIScale == nil then
+        GSE_C.MenuUIScale = ClampUIScale(GSE_C.UIScale)
+    end
+    GSE_C.MenuUIScale = ClampUIScale(value)
+    if GSE.ApplyMenuUIScale then GSE.ApplyMenuUIScale() end
+end
+
+GSE.UIScaleFrames = GSE.UIScaleFrames or setmetatable({}, {__mode = "k"})
+GSE.MenuUIScaleFrames = GSE.MenuUIScaleFrames or setmetatable({}, {__mode = "k"})
+
+function GSE.ClampFrameToScreen(frame)
+    if not (frame and frame.GetRect and frame.SetPoint and frame.ClearAllPoints and UIParent) then return end
+
+    local parentLeft, parentBottom, parentWidth, parentHeight = GetUIParentRect()
+
+    local left, bottom, width, height = frame:GetRect()
+    if not (left and bottom and width and height and parentWidth > 0 and parentHeight > 0) then return end
+
+    local minLeft = parentLeft + GSE_UI_SCREEN_BUFFER
+    local minBottom = parentBottom + GSE_UI_SCREEN_BUFFER
+    local maxLeft = parentLeft + parentWidth - width - GSE_UI_SCREEN_BUFFER
+    local maxBottom = parentBottom + parentHeight - height - GSE_UI_SCREEN_BUFFER
+    local clampedLeft = width > (parentWidth - (GSE_UI_SCREEN_BUFFER * 2)) and
+        (parentLeft + ((parentWidth - width) / 2)) or
+        math.min(math.max(left, minLeft), maxLeft)
+    local clampedBottom = height > (parentHeight - (GSE_UI_SCREEN_BUFFER * 2)) and
+        (parentBottom + ((parentHeight - height) / 2)) or
+        math.min(math.max(bottom, minBottom), maxBottom)
+
+    if math.abs(clampedLeft - left) < 0.5 and math.abs(clampedBottom - bottom) < 0.5 then return end
+
+    GSE.SetFrameScreenPoint(frame, "BOTTOMLEFT", clampedLeft, clampedBottom)
+end
+
+function GSE.ApplyScaleToFrame(frame, scale)
+    if not (frame and frame.SetScale) then return end
+
+    scale = ClampUIScale(scale or GSE.GetUIScale())
+    local preserveCenter = frame.IsShown and frame:IsShown() and frame.GetCenter and frame.ClearAllPoints and frame.SetPoint
+        and not frame.GSESkipScaleRecenter
+    local centerX, centerY
+    if preserveCenter then
+        centerX, centerY = frame:GetCenter()
+        preserveCenter = centerX and centerY and UIParent
+    end
+
+    frame:SetScale(scale)
+
+    if preserveCenter then
+        GSE.SetFrameScreenPoint(frame, "CENTER", centerX, centerY)
+        GSE.ClampFrameToScreen(frame)
+    end
+end
+
+function GSE.ApplyMenuScaleToFrame(frame)
+    if not (frame and frame.SetScale) then return end
+    GSE.ApplyScaleToFrame(frame, GSE.GetMenuUIScale())
+end
+
+function GSE.RegisterUIScaleFrame(frame)
+    if not frame then return end
+    GSE.UIScaleFrames = GSE.UIScaleFrames or setmetatable({}, {__mode = "k"})
+    GSE.UIScaleFrames[frame] = true
+    GSE.ApplyScaleToFrame(frame)
+end
+
+function GSE.RegisterMenuUIScaleFrame(frame)
+    if not frame then return end
+    GSE.MenuUIScaleFrames = GSE.MenuUIScaleFrames or setmetatable({}, {__mode = "k"})
+    GSE.MenuUIScaleFrames[frame] = true
+    GSE.ApplyMenuScaleToFrame(frame)
+end
+
+function GSE.ApplyUIScale()
+    if GSE.UIScaleFrames then
+        for frame in pairs(GSE.UIScaleFrames) do
+            if frame and frame.SetScale then
+                GSE.ApplyScaleToFrame(frame)
+            else
+                GSE.UIScaleFrames[frame] = nil
+            end
+        end
+    end
+end
+
+function GSE.ApplyMenuUIScale()
+    if GSE.MenuUIScaleFrames then
+        for frame in pairs(GSE.MenuUIScaleFrames) do
+            if frame and frame.SetScale then
+                GSE.ApplyMenuScaleToFrame(frame)
+            else
+                GSE.MenuUIScaleFrames[frame] = nil
+            end
+        end
+    end
+    if GSE.MenuFrame then
+        GSE.ApplyMenuScaleToFrame(GSE.MenuFrame)
+    end
+end
+
+end
+table.insert(ns.deferred, setup)

--- a/GSE_Utils/GSE_Utils.toc
+++ b/GSE_Utils/GSE_Utils.toc
@@ -33,5 +33,6 @@ Indent.lua
 Events.lua
 StaticPopup.lua
 Utils.lua
+Appearance.lua
 Tracker.lua
 MacroSync.lua


### PR DESCRIPTION
Replaces the two mutually-exclusive Native/Modern skin checkboxes in the options panel with a single **Skin** dropdown: **Native**, **Modern**, and a dynamic addon-specific entry labelled **ElvUI** or **EllesmereUI** (shown only when that addon is installed).

### Behaviour
- New saved variable `GSEOptions.SkinMode` (`"NATIVE"`/`"MODERN"`/`"ADDON"`; unset = **AUTO**). AUTO uses the installed addon skin when present, otherwise Native; an explicit choice is always honoured. Migrates the old boolean `GSEOptions.UseModernSkin` (`true` -> `"MODERN"`, otherwise AUTO) and keeps it in sync for downgrade safety.
- Provider selection in `GSE_GUI/Skin.lua` now honours the mode: ElvUI/EllesmereUI only drives GSE's look when the effective mode is `"ADDON"`, so choosing Native or Modern is respected even with one installed (previously the external provider always won).

### Refactor
- Moves the front-end-only helpers (skin accessors, UI-scale subsystem, frame-positioning math) out of core `GSE/API/InitialOptions.lua` into a new `GSE_Utils/Appearance.lua`. The macro engine never calls them; `GSE_Utils` is the lowest shared front-end dependency (`GSE_Options` and `GSE_GUI` both depend on it), so they stay available without forcing the LoadOnDemand `GSE_GUI` to load. Core keeps only the saved-variable defaults + migration.

No change to the macro engine. luacheck (std=lua51) / busted unaffected -- no spec or core file references the moved functions.

Addresses #1930.

🤖 Generated with [Claude Code](https://claude.com/claude-code)