### PR TITLE
ENH: Editor toolbar/layout, live tree updates, options ordering

### DIFF
--- a/GSE_GUI/Editor.lua
+++ b/GSE_GUI/Editor.lua
@@ -6121,6 +6121,32 @@ function GSE.CreateEditor()
                         sequence.MetaData.Scenario = tonumber(sequence.MetaData.Scenario) - 1
                     end
                     table.remove(sequence.Versions, version)
+
+                    -- Mirror the deletion into the Library display cache so the
+                    -- tree drops the version node immediately, before any Save
+                    -- (GSESequences is only written on explicit Save). The tree is
+                    -- built from GSE.Library, not editframe.Sequence, so without
+                    -- this the deleted version lingered until save. Same approach
+                    -- as the New Version handler and the drag-reorder handler.
+                    local delClassID = tonumber(editframe.ClassID)
+                    if delClassID then
+                        GSE.EnsureSequenceLoaded(delClassID, editframe.SequenceName)
+                        local libSeq = GSE.Library[delClassID] and GSE.Library[delClassID][editframe.SequenceName]
+                        if libSeq and libSeq.Versions and libSeq.Versions[version] then
+                            table.remove(libSeq.Versions, version)
+                            if libSeq.MetaData then
+                                libSeq.MetaData.Default = sequence.MetaData.Default
+                                local contextKeys = {
+                                    "Raid", "Arena", "Mythic", "MythicPlus", "PVP",
+                                    "Heroic", "Dungeon", "Timewalking", "Party", "Scenario",
+                                }
+                                for _, ck in ipairs(contextKeys) do
+                                    libSeq.MetaData[ck] = sequence.MetaData[ck]
+                                end
+                            end
+                        end
+                    end
+
                     printtext = printtext .. " " .. L["This change will not come into effect until you save this macro."]
                     editframe.ManageTree()
                     treeContainer:SelectByValue(path)
@@ -6568,32 +6594,22 @@ function GSE.CreateEditor()
 
             if selectedPath and #selectedPath > 0 then
                 if type(selectedAction) == "table" then
-                    if selectedAction.Type == Statics.Actions.Loop or selectedAction.Type == Statics.Actions.If then
-                        local targetPath = CloneMacroBlockPath(selectedPath)
-                        if selectedAction.Type == Statics.Actions.If then
-                            table.insert(targetPath, 1)
+                    -- Always insert the new block as a sibling immediately AFTER
+                    -- the focused block, in the same container. Focusing a Loop or
+                    -- If block therefore adds a new block BELOW it (a sibling), not
+                    -- inside it; to add inside a loop or an If branch, focus one of
+                    -- its child blocks and the new block lands right after that.
+                    local parentPath = ParentMacroBlockPath(selectedPath)
+                    local targetList = GetTopButtonActionList(parentPath)
+                    local selectedIndex = tonumber(selectedPath[#selectedPath])
+                    local insertAt = selectedIndex and selectedIndex + 1
+                    if type(targetList) == "table" and insertAt then
+                        if insertAt > #targetList + 1 then
+                            insertAt = #targetList + 1
                         end
-
-                        local targetList = GetTopButtonActionList(targetPath)
-                        if type(targetList) == "table" then
-                            local insertAt = #targetList + 1
-                            table.insert(targetList, insertAt, newAction)
-                            insertedPath = CloneMacroBlockPath(targetPath)
-                            table.insert(insertedPath, insertAt)
-                        end
-                    else
-                        local parentPath = ParentMacroBlockPath(selectedPath)
-                        local targetList = GetTopButtonActionList(parentPath)
-                        local selectedIndex = tonumber(selectedPath[#selectedPath])
-                        local insertAt = selectedIndex and selectedIndex + 1
-                        if type(targetList) == "table" and insertAt then
-                            if insertAt > #targetList + 1 then
-                                insertAt = #targetList + 1
-                            end
-                            table.insert(targetList, insertAt, newAction)
-                            insertedPath = CloneMacroBlockPath(parentPath)
-                            table.insert(insertedPath, insertAt)
-                        end
+                        table.insert(targetList, insertAt, newAction)
+                        insertedPath = CloneMacroBlockPath(parentPath)
+                        table.insert(insertedPath, insertAt)
                     end
                 end
             end
@@ -7082,7 +7098,7 @@ function GSE.CreateEditor()
         local versionLabel = UI:Create("EditBox")
         versionLabel:SetWidth(150)
         versionLabel:SetHeight(40)
-        if versionLabel.SetFlowOffset then versionLabel:SetFlowOffset(0, 16) end
+        if versionLabel.SetFlowOffset then versionLabel:SetFlowOffset(0, 10) end
         versionLabel:SetLabel(L["Version"] .. " " .. L["Name"])
         versionLabel:SetText(BuildVersionLabel(version, editframe.Sequence.Versions[version].Label, true))
         versionLabel:SetCallback(
@@ -7105,8 +7121,8 @@ function GSE.CreateEditor()
         linegroup1:AddChild(staticHeaderIndent)
         linegroup1:AddChild(addActionButton)
         linegroup1:AddChild(addLoopButton)
-        linegroup1:AddChild(addIfButton)
         linegroup1:AddChild(addPauseButton)
+        linegroup1:AddChild(addIfButton)
         linegroup1:AddChild(addEmbedButton)
         linegroup1:AddChild(moveUpButton)
         linegroup1:AddChild(moveDownButton)

--- a/GSE_GUI/Editor_Tree.lua
+++ b/GSE_GUI/Editor_Tree.lua
@@ -1253,14 +1253,35 @@ local function onClick_Sequences(editframe, container, group, unique, path, key,
         end
         ShowSequenceFooter(editframe)
         if editframe.RefreshMacroLimitSaveState then editframe:RefreshMacroLimitSaveState() end
-        table.insert(
-            editframe.Sequence.Versions,
-            GSE.CloneSequence(editframe.Sequence.Versions[editframe.Sequence.MetaData.Default])
-        )
-        editframe.GUIDrawMacroEditor(contentcontainer, #editframe.Sequence.Versions, table.concat(path, "\001"))
+        local newVersion = GSE.CloneSequence(editframe.Sequence.Versions[editframe.Sequence.MetaData.Default])
+        table.insert(editframe.Sequence.Versions, newVersion)
+        local newVersionIndex = #editframe.Sequence.Versions
+
+        -- Mirror the new version into the Library display cache so the tree shows
+        -- the node immediately, before any Save (GSESequences is only written on
+        -- explicit Save). Same approach as the version drag-reorder handler above.
+        local numericClassID = tonumber(classid)
+        if numericClassID then
+            GSE.EnsureSequenceLoaded(numericClassID, sequencename)
+            local libSeq = GSE.Library[numericClassID] and GSE.Library[numericClassID][sequencename]
+            if libSeq and libSeq.Versions then
+                table.insert(libSeq.Versions, GSE.CloneSequence(newVersion))
+            end
+        end
+
+        editframe.GUIDrawMacroEditor(contentcontainer, newVersionIndex, table.concat(path, "\001"))
         editframe:SetTitle(
             L["Sequence Editor"] .. ": " .. sequencename .. " (" .. L["New"] .. " " .. L["Version"] .. ")"
         )
+
+        -- Rebuild the tree so the new version node appears right away, then select
+        -- it (deferred to avoid re-entering this handler) so it becomes the active
+        -- node for editing. Saving later persists it normally.
+        if editframe.ManageTree then editframe.ManageTree() end
+        local newVersionPath = table.concat(path, "\001") .. "\001" .. tostring(newVersionIndex)
+        C_Timer.After(0, function()
+            GSE.GUI.SelectEditorTreePath(editframe, newVersionPath)
+        end)
     else
         if editframe.OrigSequenceName ~= sequencename then
             GSE.GUILoadEditor(editframe, path[#path])

--- a/GSE_Options/Options.lua
+++ b/GSE_Options/Options.lua
@@ -2136,6 +2136,15 @@ end
 
 local function createBlizzOptions(category, pluginOptions, colourOptions)
     local windowOptions = Settings.RegisterVerticalLayoutSubcategory(category, "Windows & Layout")
+    -- Skyriding / Vehicle Keybinds (Retail only) is registered HERE so it sits
+    -- directly above Tools & Diagnostics. Its slot buttons/initializers are
+    -- populated later by GSE_QoL/QoL.lua, which loads after this runs and picks
+    -- up GSE.SkyridingOptionsCategory rather than registering its own
+    -- subcategory (which would land last, below Tools & Diagnostics).
+    if GSE.GameMode and GSE.GameMode >= 11 then
+        GSE.SkyridingOptionsCategory =
+            Settings.RegisterVerticalLayoutSubcategory(category, L["Skyriding / Vehicle Keybinds"])
+    end
     local troubleOptions = Settings.RegisterVerticalLayoutSubcategory(category, "Tools & Diagnostics")
     AttachTrackerDefaultsHandler(troubleOptions)
     --@debug@

--- a/GSE_QoL/QoL.lua
+++ b/GSE_QoL/QoL.lua
@@ -164,7 +164,10 @@ if GSE.GameMode >= 11 then
     -- standard Blizzard APIs (11.0+); the panel rebuilds each open from
     -- the initializer data so the displayed text always reflects what
     -- was saved.
-    local skyOptions = Settings.RegisterVerticalLayoutSubcategory(
+    -- Prefer the subcategory pre-registered by GSE_Options/Options.lua
+    -- (createBlizzOptions) so this page sits ABOVE Tools & Diagnostics. Fall
+    -- back to registering our own (lands last) if it isn't there for any reason.
+    local skyOptions = GSE.SkyridingOptionsCategory or Settings.RegisterVerticalLayoutSubcategory(
         Settings.GetCategory(GSE.MenuCategoryID),
         L["Skyriding / Vehicle Keybinds"]
     )


### PR DESCRIPTION
Editor toolbar/layout tweaks (Pause/If order, Version Name centering, sibling-after-focused block insertion), instant tree updates for new/deleted versions before save, and Skyriding moved above Tools & Diagnostics. Refs #1957.