### PR TITLE
#1981 Store explicit content-type version; never collapse to nil

### DIFF
--- a/GSE_GUI/Editor_Metadata.lua
+++ b/GSE_GUI/Editor_Metadata.lua
@@ -814,14 +814,17 @@ local function drawMetadataTab(editframe, container)
         dd:SetCallback(
             "OnValueChanged",
             function(obj, event, key)
-                if editframe.Sequence.MetaData.Default == tonumber(key) then
-                    editframe.Sequence.MetaData[metaKey] = nil
-                else
-                    editframe.Sequence.MetaData[metaKey] = tonumber(key)
-                    -- PVP also mirrors editframe.PVP (original behaviour)
-                    if metaKey == "PVP" then
-                        editframe.PVP = tonumber(key)
-                    end
+                -- Always store the version the user picked. Previously a
+                -- pick equal to the Default was collapsed to nil, but nil
+                -- and an explicit version do not resolve the same at
+                -- runtime (an explicit pin runs the chosen version; nil
+                -- fell back to v1 in a Delve even with Default=2), so the
+                -- setting silently failed to apply. Storing the explicit
+                -- number makes every row behave like the pin that works.
+                editframe.Sequence.MetaData[metaKey] = tonumber(key)
+                -- PVP also mirrors editframe.PVP (original behaviour)
+                if metaKey == "PVP" then
+                    editframe.PVP = tonumber(key)
                 end
             end
         )

--- a/GSE_GUI/Editor_Tree.lua
+++ b/GSE_GUI/Editor_Tree.lua
@@ -1633,21 +1633,17 @@ local function ManageTree(editframe)
                 return v
             end
 
-            -- Update all MetaData fields that hold a version index.
-            -- Context keys that equal Default are stored as nil; re-apply that rule
-            -- after remapping (mirrors the editor's OnValueChanged logic).
+            -- Update all MetaData fields that hold a version index. Keep an
+            -- explicit context version explicit — do NOT collapse it to nil
+            -- when it matches Default (mirrors the editor's OnValueChanged;
+            -- nil and an explicit version do not resolve the same at runtime).
             seq.MetaData.Default = remapVersionIndex(seq.MetaData.Default)
             local contextKeys = {
                 "Raid", "Arena", "Mythic", "MythicPlus", "PVP",
                 "Heroic", "Dungeon", "Timewalking", "Party", "Scenario",
             }
             for _, k in ipairs(contextKeys) do
-                local remapped = remapVersionIndex(seq.MetaData[k])
-                if remapped == seq.MetaData.Default then
-                    seq.MetaData[k] = nil
-                else
-                    seq.MetaData[k] = remapped
-                end
+                seq.MetaData[k] = remapVersionIndex(seq.MetaData[k])
             end
 
             -- Mirror the reorder into the Library copy so ManageTree() draws the


### PR DESCRIPTION
Fixes #1981

## Problem
On the Configuration tab, picking a PvE/PvP content version (Delves/Scenarios, Raid, Dungeon, Mythic+, Solo, Arena…) that **equals the Default Version** was silently discarded — stored as `nil`. `nil` and an explicit version index do not resolve the same at runtime (`GSE.GetActiveSequenceVersion` treats an empty context key as "no override"), so the sequence kept running the wrong version in that content.

Repro: Default=2, Delves=2 → saved as `nil` → v1 runs in a Delve. Contrast Default=1, Delves=2 → saved as `2` → v2 runs. The explicit store works; the nil-collapse is what breaks it.

## Fix
- `GSE_GUI/Editor_Metadata.lua` versionDropdown `OnValueChanged`: always store the version picked; removed the `== Default → nil` collapse.
- `GSE_GUI/Editor_Tree.lua` version drag-reorder remap: keep explicit context versions; removed the matching nil-collapse.

Delete Version already stores an explicit Default — untouched.

## Verified
In-game: Default=2 + Delves=2 → `MetaData.Scenario` saves as `2` (round-trip decode confirmed) → v2 runs in the Delve. `luac -p` clean. Pure table/UI logic, cross-version safe. 2 files, +16/−17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)