### PR TITLE
#1984 Restore GSE.PlayerSpellsLoaded so the editor opens in combat again

### DIFF
--- a/GSE_QoL/QoL.lua
+++ b/GSE_QoL/QoL.lua
@@ -14,6 +14,25 @@ local L = GSE.L
 -- ============================================================================
 
 
+-- Restores the #1752 in-combat editor gate (e2c23552). GSE.ShowSequences
+-- allows opening in combat only when `GSE.PlayerSpellsLoaded` exists and
+-- returns true. The original QoL implementation (a scanned playerSpells
+-- cache) was deleted in a later refactor, leaving the Editor.lua call
+-- dangling on a nil function -- so the editor silently went back to
+-- always refusing to open in combat, while the ungated Keybindings
+-- button opened the very same window in combat without error. Stateless
+-- reimplementation: ask the spellbook directly ("is the spellbook
+-- populated yet" is all the old cache actually answered).
+function GSE.PlayerSpellsLoaded()
+    if C_SpellBook and C_SpellBook.GetNumSpellBookSkillLines then
+        return (C_SpellBook.GetNumSpellBookSkillLines() or 0) > 0
+    end
+    if GetNumSpellTabs then
+        return (GetNumSpellTabs() or 0) > 0
+    end
+    return false
+end
+
 -- Native WoW icon picker, owned by GSE.
 --
 -- Pattern lifted from Jaliborc/BagBrother config/panels/ruleEdit.lua Ã¢â‚¬â€


### PR DESCRIPTION
Fixes #1984

## Problem
`GSE.ShowSequences()` blocks in combat, while `GSE.ShowKeyBindings()` opens the same editor window in combat with no error. The combat-open feature from #1752 (e2c23552) regressed: its gate calls `GSE.PlayerSpellsLoaded()`, whose GSE_QoL definition was deleted in a later refactor — the reference now resolves to nil, so the escape hatch never fires and the editor always refuses in combat.

## Fix
Reimplement `GSE.PlayerSpellsLoaded()` in `GSE_QoL/QoL.lua` where it originally lived, but stateless — ask the spellbook directly instead of maintaining the old scanned `playerSpells` cache:

- Retail: `C_SpellBook.GetNumSpellBookSkillLines() > 0`
- Classic fallback: `GetNumSpellTabs() > 0`

`Editor.lua` is untouched (its gate already calls the function when present). Builds without GSE_QoL keep the current block-in-combat behaviour, matching how #1752 originally shipped.

## Verified
In-game: with the fix, opening Sequences during combat works with no Lua error — identical to the Keybindings path. `luac -p` clean. 1 file, +19.

🤖 Generated with [Claude Code](https://claude.com/claude-code)