### PR TITLE
#1983 Guard Library mirrors against post-Save aliasing in version handlers

### DIFF
--- a/GSE_GUI/Editor.lua
+++ b/GSE_GUI/Editor.lua
@@ -6028,9 +6028,14 @@ function GSE.CreateEditor()
                         printtext = printtext .. " " .. L["Delves and Scenarios setting changed to Default."]
                     end
 
-                    if sequence.MetaData.Default > 1 then
+                    -- Only shift Default down when the deleted version sat at or
+                    -- before it (same rule as the content keys below). It used to
+                    -- decrement unconditionally, so deleting a version AFTER the
+                    -- Default wrongly moved the Default onto a different version.
+                    if sequence.MetaData.Default > 1 and sequence.MetaData.Default >= version then
                         sequence.MetaData.Default = tonumber(sequence.MetaData.Default) - 1
-                    else
+                    end
+                    if GSE.isEmpty(sequence.MetaData.Default) or sequence.MetaData.Default < 1 then
                         sequence.MetaData.Default = 1
                     end
 
@@ -6106,7 +6111,12 @@ function GSE.CreateEditor()
                     if delClassID then
                         GSE.EnsureSequenceLoaded(delClassID, editframe.SequenceName)
                         local libSeq = GSE.Library[delClassID] and GSE.Library[delClassID][editframe.SequenceName]
-                        if libSeq and libSeq.Versions and libSeq.Versions[version] then
+                        -- After a Save, ReplaceSequence stores the editor's own
+                        -- sequence object into GSE.Library, so libSeq IS `sequence`
+                        -- (same table, same Versions array). Removing again here
+                        -- deleted a SECOND version — delete one, lose them all
+                        -- (2 versions -> 0). Only mirror when it's a distinct copy.
+                        if libSeq and libSeq ~= sequence and libSeq.Versions and libSeq.Versions[version] then
                             table.remove(libSeq.Versions, version)
                             if libSeq.MetaData then
                                 libSeq.MetaData.Default = sequence.MetaData.Default

--- a/GSE_GUI/Editor_Tree.lua
+++ b/GSE_GUI/Editor_Tree.lua
@@ -1286,7 +1286,11 @@ local function onClick_Sequences(editframe, container, group, unique, path, key,
         if numericClassID then
             GSE.EnsureSequenceLoaded(numericClassID, sequencename)
             local libSeq = GSE.Library[numericClassID] and GSE.Library[numericClassID][sequencename]
-            if libSeq and libSeq.Versions then
+            -- After a Save, ReplaceSequence stores the editor's own sequence object
+            -- into GSE.Library, so libSeq IS editframe.Sequence (same Versions array).
+            -- Inserting again here created TWO new versions and desynced the index
+            -- (nil-index crash in GUIDrawMacroEditor). Only mirror a distinct copy.
+            if libSeq and libSeq ~= editframe.Sequence and libSeq.Versions then
                 table.insert(libSeq.Versions, GSE.CloneSequence(newVersion))
             end
         end
@@ -1654,7 +1658,10 @@ local function ManageTree(editframe)
             -- correct order.  This does NOT persist to GSESequences.
             GSE.EnsureSequenceLoaded(classid, seqname)
             local libSeq = GSE.Library[classid] and GSE.Library[classid][seqname]
-            if libSeq and libSeq.Versions then
+            -- After a Save, libSeq IS `seq` (same Versions array); a second
+            -- remove/insert would re-move the version and scramble the order.
+            -- Only mirror when the Library holds a distinct copy.
+            if libSeq and libSeq ~= seq and libSeq.Versions then
                 local libMoved = table.remove(libSeq.Versions, srcIdx)
                 table.insert(libSeq.Versions, dstIdx, libMoved)
                 libSeq.MetaData.Default = seq.MetaData.Default


### PR DESCRIPTION
Fixes #1983

Standalone resubmit of the second commit from closed PR #1982 — this part is independent of the content-version storage discussion there and addresses the still-open crash family in #1983.

## Problem
After a Save, `GSE.ReplaceSequence` stores the editor's own sequence object into `GSE.Library`, so `editframe.Sequence` and the Library entry are the **same table**. The editor's per-version handlers also "mirror" their change into the Library display cache, which post-Save runs twice on one `Versions` array:

- **Delete Version** removes two versions per click (2 → 0; the tree shows no version rows).
- **New Version** inserts two copies, then `Editor.lua:5889: attempt to index field '?' (a nil value)` in `GUIDrawMacroEditor`.
- **Drag-reorder** applies the move twice, scrambling order.

All three work before the first Save of the session (separate copies) — that's the tell.

## Fix
Guard the three mirror sites with `libSeq ~= sequence` so the mirror only runs when the Library holds a distinct copy. Also: Delete Version decremented `MetaData.Default` unconditionally; it now only shifts when the deleted index is at/before the Default (same rule the content-type keys already use).

## Verified
In-game: delete keeps the remaining versions; New Version creates exactly one with no error. `luac -p` clean. 2 files, +22/−5, cherry-picked onto current master (34b29a5d).

🤖 Generated with [Claude Code](https://claude.com/claude-code)