### PR TITLE
#1994 Anchor the Tab spell-list menu to the live editbox, not a stale editor frame

### DIFF
--- a/GSE_GUI/Editor.lua
+++ b/GSE_GUI/Editor.lua
@@ -7381,14 +7381,19 @@ function GSE.CreateEditor()
             -- Variable menu on Tab. The spell field applies via SetText so its
             -- own OnTextChanged stores the value; the macro box inserts at the
             -- cursor and its OnTextChanged owns storage. No-ops when GSE_QoL
-            -- is not loaded.
+            -- is not loaded. Pass `frame` (the CURRENT editor's frame, supplied
+            -- by the caller) -- not editframe.frame: this factory is defined
+            -- once inside the first editor ever created, so that upvalue is
+            -- the FIRST editor's frame forever. After the editor is re-created
+            -- it is hidden, and Blizzard refuses to open a context menu on a
+            -- hidden owner -- the Tab menu silently stopped appearing.
             if GSE.OnEditorSpellTab then
-                GSE.OnEditorSpellTab(spellEditBox, editframe.frame, function(value)
+                GSE.OnEditorSpellTab(spellEditBox, frame, function(value)
                     spellEditBox:SetText(value)
                 end)
             end
             if GSE.OnEditorMacroBlockTab then
-                GSE.OnEditorMacroBlockTab(macroEditBox, editframe.frame)
+                GSE.OnEditorMacroBlockTab(macroEditBox, frame)
             end
             return spellEditBox, macroEditBox
         end

--- a/GSE_QoL/QoL.lua
+++ b/GSE_QoL/QoL.lua
@@ -309,7 +309,7 @@ GSE.OnEditorSpellTab = function(widget, menuOwner, apply)
     local editBox = widget and (widget.editBox or widget.editbox)
     if not editBox then return end
     editBox:SetScript("OnTabPressed", function()
-        MenuUtil.CreateContextMenu(menuOwner, function(ownerRegion, rootDescription)
+        MenuUtil.CreateContextMenu(editBox, function(ownerRegion, rootDescription)
             rootDescription:CreateTitle(L["Insert Spell"])
             for _, v in ipairs(getPlayerSpells()) do
                 rootDescription:CreateButton(v, function() apply(v) end)
@@ -326,7 +326,7 @@ GSE.OnEditorMacroBlockTab = function(widget, menuOwner)
     local editBox = widget and (widget.editBox or widget.editbox)
     if not editBox then return end
     editBox:SetScript("OnTabPressed", function()
-        MenuUtil.CreateContextMenu(menuOwner, function(ownerRegion, rootDescription)
+        MenuUtil.CreateContextMenu(editBox, function(ownerRegion, rootDescription)
             rootDescription:CreateTitle(L["Insert Spell"])
             for _, v in ipairs(getPlayerSpells()) do
                 rootDescription:CreateButton(v, function() editBox:Insert(v) end)
@@ -345,7 +345,7 @@ end
 -- variable / test case (boolean field) or a variable / sequence (managed macro).
 GSE.OnEditorBooleanTab = function(editBox, menuOwner, apply)
     editBox:SetScript("OnTabPressed", function()
-        MenuUtil.CreateContextMenu(menuOwner, function(ownerRegion, rootDescription)
+        MenuUtil.CreateContextMenu(editBox, function(ownerRegion, rootDescription)
             rootDescription:CreateTitle(L["Insert GSE Variable"])
             for k, _ in pairs(GSEVariables) do
                 rootDescription:CreateButton(k, function() apply([[=GSE.V["]] .. k .. [["]()]]) end)
@@ -358,7 +358,7 @@ GSE.OnEditorBooleanTab = function(editBox, menuOwner, apply)
 end
 GSE.OnEditorMacroTab = function(editBox, menuOwner)
     editBox:SetScript("OnTabPressed", function()
-        MenuUtil.CreateContextMenu(menuOwner, function(ownerRegion, rootDescription)
+        MenuUtil.CreateContextMenu(editBox, function(ownerRegion, rootDescription)
             rootDescription:CreateTitle(L["Insert GSE Variable"])
             for k, _ in pairs(GSEVariables) do
                 rootDescription:CreateButton(k, function()


### PR DESCRIPTION
Fixes #1994 (follow-up to #1989)

## Problem
The Tab spell list worked after a /reload, then silently stopped once the editor had been re-created (e.g. across a combat transition). Debug at failure: `owner shown= false, editors= 1, ownerIsNewest= false` — the handler fires, but its menu owner is a hidden frame, and Blizzard won't open a context menu on a hidden region.

Root cause: `GSE.CreateSpellEditBox` is defined once (`if GSE.isEmpty(...)`) inside the first editor created, so `editframe` inside it is a permanent upvalue to that first editor. The #1989 wiring passed `editframe.frame` as the menu owner instead of the factory's `frame` parameter — my mistake in that PR.

## Fix (2 files, +12/−7)
- **Editor.lua** — pass the factory's `frame` parameter (the current editor's frame) to `OnEditorSpellTab` / `OnEditorMacroBlockTab`.
- **QoL.lua** — anchor all four Tab menus to the editbox itself (visible by definition when Tab fires), the same approach the icon Select menu takes with its panel-local frame. Belt and braces.

Heads-up (not changed here): the same factory passes the stale `editframe` upvalue to `UpdateMacroLimitState(..., editframe, version)` — the 255-char Save state may be updating the dead editor after a re-create.

## Verified
In-game: the menu now appears every time, including after combat transitions. `luac -p` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)