### PR TITLE
#2002 Keep a macro block's height fit inside the block

### DIFF
--- a/GSE_GUI/Editor.lua
+++ b/GSE_GUI/Editor.lua
@@ -692,9 +692,17 @@ local function FitMacroEditBoxToContent(macroEditBox, text)
     -- macroFields, macroBody -- sized at draw time); auto-height ancestors
     -- above them only follow if those grow too. Push the delta up through
     -- every fixed-height ancestor, relaying out as we go.
+    -- ...but ONLY within this block. The first auto-height ancestor is the block
+    -- panel, which recomputes its height from its children; everything above it
+    -- (the block list, the scroll frame, the window) is SHARED chrome. Resizing
+    -- those by the delta made every block on load shrink the same containers
+    -- again, collapsing the list so it no longer filled the window. Past that
+    -- boundary we only re-lay out, never resize.
     local parent = macroEditBox.parent
+    local sharedChrome = false
     while parent do
-        if delta ~= 0 and parent.explicitHeight and not parent.autoAdjustHeight
+        if parent.autoAdjustHeight then sharedChrome = true end
+        if not sharedChrome and delta ~= 0 and parent.explicitHeight
             and parent.height and parent.SetHeight then
             parent:SetHeight(parent.height + delta)
         elseif parent.DoLayout then


### PR DESCRIPTION
Fixes #2002

Since the macro-command box auto-fit, opening a sequence with several action blocks left the block list short — it stopped before the bottom of the window with empty space below and the last block clipped.

`FitMacroEditBoxToContent` pushes the delta of a re-fitted box up through its fixed-height ancestors, but the walk ran to the top of the widget tree. Only the containers inside a block should absorb that delta; above the block panel sit shared containers (block list, layout container, scroll frame), and **every** block's fit on load subtracted its own delta from those same containers again — roughly -36px per block going from the 5-row baseline to the 3-row minimum.

The walk now stops resizing at the first auto-height ancestor, which recomputes its height from its children; above that boundary it only re-lays out.

### Testing

- `luac -p` clean.
- Confirmed in a running client: the editor fills the window with macro blocks on load again, and a block still grows and shrinks as its text changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)