### PR TITLE
#2008 Use the version selected for the content

### DIFF
--- a/GSE/API/Events.lua
+++ b/GSE/API/Events.lua
@@ -1588,6 +1588,15 @@ function GSE:PLAYER_TALENT_UPDATE()
 end
 
 function GSE:GROUP_ROSTER_UPDATE(...)
+    -- inParty is read by the version resolver but was only refreshed on a zone
+    -- change, so joining or leaving a group in the same zone left the sequence
+    -- on the version for the group state it no longer had. Re-resolve when the
+    -- state actually flips -- not on every roster tick.
+    local grouped = IsInGroup() and true or false
+    if grouped ~= GSE.inParty then
+        GSE.inParty = grouped
+        GSE.ReloadSequences()
+    end
     -- Serialisation stuff
     GSE.sendVersionCheck()
     for k, _ in pairs(GSE.UnsavedOptions["PartyUsers"]) do

--- a/GSE/API/Storage.lua
+++ b/GSE/API/Storage.lua
@@ -1145,10 +1145,31 @@ function GSE.GetActiveSequenceVersion(sequenceName)
     if not GSE.isEmpty(meta.PVESolo) and isPVESoloContext() then
         vers = meta.PVESolo
     end
+    -- "Party" means in a party IN THE WORLD, but GSE.inParty is IsInGroup(),
+    -- which is equally true inside every delve, dungeon and raid. It is also the
+    -- LAST rule, so it used to pick up any instance whose own rule named no
+    -- version -- claiming content the author had configured elsewhere. Instance
+    -- content is never "the world": rule it out there.
+    local inInstanceContent = GSE.inScenario or GSE.inRaid or GSE.inDungeon
+        or GSE.inHeroic or GSE.inMythic or GSE.inMythicPlus or GSE.inTimeWalking
+        or GSE.inArena
     for _, ctx in ipairs(contextVersionPriority) do
-        if meta[ctx.metaKey] and GSE[ctx.flag] then
-            vers = meta[ctx.valueKey]
+        if ctx.flag == "inParty" and inInstanceContent then
             break
+        end
+        -- A context only claims the sequence if it names a REAL version. Bare
+        -- truthiness is not enough: "" and 0 are both truthy in Lua, so a key
+        -- left empty by an import or an older save would win here and resolve
+        -- to nothing (or to 1, via the zero check below) instead of falling
+        -- through to the Default. The VALUE is checked too, not just the key,
+        -- because a row can read a different field than it tests -- PVP tested
+        -- in an arena reads Arena, which may never have been set.
+        if GSE[ctx.flag] and not GSE.isEmpty(meta[ctx.metaKey]) and meta[ctx.metaKey] ~= 0 then
+            local contextVersion = meta[ctx.valueKey]
+            if not GSE.isEmpty(contextVersion) and contextVersion ~= 0 then
+                vers = contextVersion
+                break
+            end
         end
     end
     return (vers == 0) and 1 or vers

--- a/GSE_GUI/Editor_Metadata.lua
+++ b/GSE_GUI/Editor_Metadata.lua
@@ -940,14 +940,16 @@ local function drawMetadataTab(editframe, container)
         dd:SetCallback(
             "OnValueChanged",
             function(obj, event, key)
-                if editframe.Sequence.MetaData.Default == tonumber(key) then
-                    editframe.Sequence.MetaData[metaKey] = nil
-                else
-                    editframe.Sequence.MetaData[metaKey] = tonumber(key)
-                    -- PVP also mirrors editframe.PVP (original behaviour)
-                    if metaKey == "PVP" then
-                        editframe.PVP = tonumber(key)
-                    end
+                -- Store what the author picked, even when it equals the Default.
+                -- Dropping it looked harmless (both resolve to the same version
+                -- today) but it is not: an unset context falls THROUGH to the
+                -- next matching rule, so a lower-priority key -- Party, say --
+                -- silently wins the content the author just configured. It also
+                -- means the setting quietly follows any later Default change.
+                editframe.Sequence.MetaData[metaKey] = tonumber(key)
+                -- PVP also mirrors editframe.PVP (original behaviour)
+                if metaKey == "PVP" then
+                    editframe.PVP = tonumber(key)
                 end
             end
         )

--- a/GSE_GUI/Editor_Tree.lua
+++ b/GSE_GUI/Editor_Tree.lua
@@ -1645,20 +1645,16 @@ local function ManageTree(editframe)
             end
 
             -- Update all MetaData fields that hold a version index.
-            -- Context keys that equal Default are stored as nil; re-apply that rule
-            -- after remapping (mirrors the editor's OnValueChanged logic).
             seq.MetaData.Default = remapVersionIndex(seq.MetaData.Default)
             local contextKeys = {
                 "Raid", "Arena", "Mythic", "MythicPlus", "PVP",
                 "Heroic", "Dungeon", "Timewalking", "Party", "Scenario",
             }
             for _, k in ipairs(contextKeys) do
-                local remapped = remapVersionIndex(seq.MetaData[k])
-                if remapped == seq.MetaData.Default then
-                    seq.MetaData[k] = nil
-                else
-                    seq.MetaData[k] = remapped
-                end
+                -- Keep a context key that equals the Default (see the editor's
+                -- OnValueChanged): dropping it lets a lower-priority key win
+                -- that content instead.
+                seq.MetaData[k] = remapVersionIndex(seq.MetaData[k])
             end
 
             -- Mirror the reorder into the Library copy so ManageTree() draws the


### PR DESCRIPTION
Fixes #2008

**Repro:** sequence with Default = 2, Delves/Scenarios = 2 → a delve runs **version 1**.

Two faults combine, and either alone sends the wrong version.

**1. The editor stored a pick equal to the Default as `nil`** (`Editor_Metadata.lua`, and again in `Editor_Tree.lua` after a version reorder). The assumption is that an absent key resolves to the Default anyway — but in `GetActiveSequenceVersion` an absent key means *this rule does not match*, so the loop continues and a **lower-priority** rule claims the content. Now it stores what the author picked.

**2. The rule that caught everything was `Party`.** `GSE.inParty` is `IsInGroup()` — true inside every delve, dungeon, raid and arena — and `Party` is the **last** entry in `contextVersionPriority`, so it picked up any instance whose own rule stored no version. `Party` means *in a party in the world*, so it is skipped when any instance context is active. It still applies grouped in the world.

The same loop also let junk values win. `9a17df9a` replaced `not GSE.isEmpty(meta[ctx.metaKey])` with bare truthiness, and in Lua **`""` and `0` are both truthy**:

- `0` matched, set `vers = 0`, and the trailing `(vers == 0) and 1 or vers` returned **1** — ignoring the Default;
- `""` matched and returned `""`;
- the `PVP` row tests `PVP` but reads `Arena`, so `PVP` set + in an arena with no `Arena` version returned **nil**.

A context now claims the sequence only when its key *and* the value it actually reads name a real version.

Finally, `inParty` was only refreshed on a zone change, so joining or leaving a group left the sequence on the version for the group state it no longer had.

### Why this touches the storage side too

#1981 was closed with "fix the selector not the storage", and most of this is indeed the selector. But the repro above is only possible because the pick was dropped: an absent key cannot mean "same as the Default" while an absent key is also what makes the loop fall through to another rule. Keeping the value is what makes the setting mean what the panel says it means.

Sequences already saved are fixed without re-saving, because the Party half of the change stops the fall-through at the source.

### Testing

- `luac -p` clean on all four files.
- Resolution verified against a standalone Lua build of the same loop, 9 cases, all passing: the repro on **existing** data (delve, grouped, Delves unset, stale `Party = 1`) → 2; after re-save (`Scenario = 2`) → 2; Delves = 3 → 3; raid with `Raid = 3` → 3; raid with `Raid` unset → Default; **world** grouped with `Party = 1` → 1 (Party still works where it means something); world solo → 2; `Raid = 0` junk → 2; arena with `PVP = 3` and no `Arena` → 3.
- Confirmed in a running client on the reported sequence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)