### PR TITLE
#2010 Draw the Spell Cache editor on first open, not at addon load

### DIFF
--- a/GSE_GUI/SpellCache.lua
+++ b/GSE_GUI/SpellCache.lua
@@ -229,9 +229,22 @@ tabgrp:SetCallback(
 tabgrp:SetFullWidth(true)
 tabgrp:SetFullHeight(true)
 
-if cacheTabs[1] then
-    tabgrp:SelectTab(cacheTabs[1].value)
-end
+-- Draw the tab's contents when the window is first SHOWN, not while the addon
+-- loads. SelectTab fires GUISelectCacheTab -> GUIDrawSpellCacheEditor, which
+-- builds two EditBoxes plus labels for EVERY cached spell. This frame starts
+-- hidden and most authors never open it, so doing that during the on-demand
+-- LoadAddOn (which is what opening the GSE menu triggers) stalled the client
+-- for seconds on a cache built up over years.
+local pendingInitialTab = cacheTabs[1] and cacheTabs[1].value
+cacheFrame.frame:HookScript(
+    "OnShow",
+    function()
+        if not pendingInitialTab then return end
+        local tab = pendingInitialTab
+        pendingInitialTab = nil
+        tabgrp:SelectTab(tab)
+    end
+)
 cacheFrame:AddChild(tabgrp)
 
 if cacheFrame and cacheFrame.frame and GSE.RegisterUIScaleFrame then


### PR DESCRIPTION
Fixes #2010

The first GSE window of a session triggers the on-demand `LoadAddOn("GSE_GUI")`, and SpellCache.lua's setup ended by selecting the first cache tab — which builds two EditBoxes plus labels for **every cached spell**, at load, for a frame that starts hidden. Long-time users (the cache only ever grows) paid a 3.5–5 s frozen client on every session's first GSE window; per-file timing put 3.8 s of a 4.4 s blocked frame in this one setup.

The initial tab draw now happens on the frame's first `OnShow` — the Spell Cache Editor pays its own cost when actually opened, and loading the GUI stops stalling the client.

### Testing

- `luac -p` clean.
- Confirmed in a running client: GSE_GUI init drops from ~3.9 s to ~17 ms; first menu-bar open is instant; the Spell Cache Editor itself still populates correctly on open (cost moves there, where it belongs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)