### PR TITLE
#2023 Clear hidden context keys on version delete instead of blocking

### DIFF
--- a/GSE/API/Storage.lua
+++ b/GSE/API/Storage.lua
@@ -1076,6 +1076,15 @@ end
 -- version that something points at is refused rather than silently repointed:
 -- an author who set Raid to version 4 chose that, and moving it to Default
 -- behind their back changes which macro fires in a raid.
+-- Context keys the resolver honours but the Configuration tab has NO row for
+-- (Editor_Metadata's pve/pvpVersionConfigs stop at Raid/Arena). A version
+-- referenced only by one of these cannot be repointed by the user -- the
+-- delete guard's "point it at another version on the Configuration tab"
+-- instruction is unfollowable -- so version deletes CLEAR them (the context
+-- falls back to Default) instead of blocking. These values arrive from older
+-- releases and imports; nothing in the current UI can set them.
+local hiddenContextKeys = { Party = true, Heroic = true, Mythic = true }
+
 function GSE.VersionReferencesInUse(metadata, version)
     local inUse = {}
     if type(metadata) ~= "table" then return inUse end
@@ -1083,9 +1092,29 @@ function GSE.VersionReferencesInUse(metadata, version)
     if not version then return inUse end
     if tonumber(metadata.Default) == version then inUse[#inUse + 1] = "Default" end
     for _, key in ipairs(contextVersionKeys) do
-        if tonumber(metadata[key]) == version then inUse[#inUse + 1] = key end
+        if not hiddenContextKeys[key] and tonumber(metadata[key]) == version then
+            inUse[#inUse + 1] = key
+        end
     end
     return inUse
+end
+
+--- Clear hidden context keys (no Configuration row) that reference `version`,
+--- so a delete is not blocked by a value the user can neither see nor change.
+--- Returns the list of cleared key names for the caller to report.
+function GSE.ClearHiddenVersionReferences(metadata, version)
+    local cleared = {}
+    if type(metadata) ~= "table" then return cleared end
+    version = tonumber(version)
+    if not version then return cleared end
+    for key in pairs(hiddenContextKeys) do
+        if tonumber(metadata[key]) == version then
+            metadata[key] = nil
+            cleared[#cleared + 1] = key
+        end
+    end
+    table.sort(cleared)
+    return cleared
 end
 
 --- Move every version reference down one slot after `version` was deleted.

--- a/GSE/Localization/ModL_enUS.lua
+++ b/GSE/Localization/ModL_enUS.lua
@@ -946,6 +946,7 @@ L["Specialisation / Class ID"] = true
 -- key-as-value fallback.
 L["This is a common WoW setting used by all addons; it controls when your action buttons respond.  On: they react when you press the key (key-down).  Off: they react when you release it (key-up).  GSE now works either way -- Actionbar Overrides and keybinds fire a single step in both states.  With this on, GSE keybinds also fire on key-down for a faster response.  Changes apply immediately out of combat (or on your next rebind if toggled mid-combat)."] = true
 L["Version %d is in use by: %s.  Point %s at another version on the Configuration tab before deleting this one."] = true
+L["Cleared hidden version reference(s) with no Configuration row: %s.  Those contexts now follow the Default version."] = true
 L["it"] = true
 L["them"] = true
 L["Announce Manual Sequence Resets"] = true

--- a/GSE_GUI/Editor.lua
+++ b/GSE_GUI/Editor.lua
@@ -6215,6 +6215,22 @@ function GSE.CreateEditor()
                 -- the rule live in Storage.lua, derived from
                 -- contextVersionPriority, so the editor cannot drift from the
                 -- runtime's idea of which contexts exist.
+                -- Hidden context keys (no Configuration row: Party/Heroic/
+                -- Mythic, from older releases/imports) cannot be repointed by
+                -- the user, so they are cleared -- that context falls back to
+                -- the Default -- rather than blocking on an instruction the
+                -- Configuration tab cannot satisfy.
+                local hiddenCleared = GSE.ClearHiddenVersionReferences
+                    and GSE.ClearHiddenVersionReferences(sequence.MetaData, version) or {}
+                if #hiddenCleared > 0 then
+                    GSE.Print(
+                        string.format(
+                            L["Cleared hidden version reference(s) with no Configuration row: %s.  Those contexts now follow the Default version."],
+                            table.concat(hiddenCleared, ", ")
+                        ),
+                        Statics.DebugModules["Editor"]
+                    )
+                end
                 local blocking = GSE.VersionReferencesInUse(sequence.MetaData, version)
                 if #blocking > 0 then
                     GSE.Print(


### PR DESCRIPTION
Fixes #2023

Deleting a version could fail with *"Version 1 is in use by: Party. Point it at another version on the Configuration tab"* — but the Configuration tab has no Party row. `Party`/`Heroic`/`Mythic` are honoured by `contextVersionPriority` and the delete guard, yet nothing in the current UI can set, show, or clear them (values arrive from older releases/imports), so the user is blocked by an instruction that cannot be followed.

The guard's rationale — make the author repoint deliberately — is preserved for every key the tab **can** repoint. Keys without a Configuration row are **cleared** during the delete (that context falls back to Default), with a chat report:

> Cleared hidden version reference(s) with no Configuration row: Party. Those contexts now follow the Default version.

`VersionReferencesInUse` skips hidden keys; new `ClearHiddenVersionReferences` clears any that reference the deleted version and returns their names. The hidden-key list lives beside the context-key derivation in Storage.lua, with a comment tying it to Editor_Metadata's row configs so the two cannot drift silently.

### Testing

- `luac -p` clean on all three files.
- Confirmed in a running client on a sequence carrying a legacy `Party = 1`: delete of version 1 previously blocked; now prints the cleared-reference line and proceeds through the normal confirm; visible keys (e.g. Raid) still block as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)