### PR TITLE
#2028 Build the tree after restoring its state, so versions show on open

### DIFF
--- a/GSE_GUI/Editor.lua
+++ b/GSE_GUI/Editor.lua
@@ -7720,8 +7720,18 @@ function GSE.ShowSequences()
     -- selected state), so building here -- before that state is restored --
     -- gave the restored sequence a node with Configuration and New Version but
     -- NO version children. The expand-click rebuild never fires on restore.
+    --
+    -- Its timestamps move with it, to the call sites below. Left here they
+    -- bracketed nothing and reported ManageTree as 0 ms while its real cost
+    -- went silently into the select+show bucket -- and this instrumentation
+    -- exists precisely to say which of the three is responsible for a slow
+    -- open. Seeded to afterCreate so the arithmetic is still safe on any path
+    -- that somehow reaches the report without building (there is none today).
+    -- The restore work in between belongs to neither bucket, so it shows up as
+    -- the gap between the three numbers and the total, which is what the
+    -- comment above openStartedAt says to read that gap as.
     --@debug@
-    local afterTree = GSE.NowMs()
+    local beforeTree, afterTree = afterCreate, afterCreate
     --@end-debug@
     -- The whole-library icon hydration used to run HERE, on every open, and it
     -- was the freeze: it force-loads every class (GSE.EnsureClassLoaded ->
@@ -7779,7 +7789,13 @@ function GSE.ShowSequences()
             -- Open to the detached tree's current node, silently: SetSelected loads
             -- the editor content via OnGroupSelected without expanding/RefreshTree.
             editframe.forceTreeSelection = true
+            --@debug@
+            beforeTree = GSE.NowMs()
+            --@end-debug@
             editframe.ManageTree()
+            --@debug@
+            afterTree = GSE.NowMs()
+            --@end-debug@
             if editframe.treeContainer.SetSelected then
                 editframe.treeContainer:SetSelected(srcStatus.selected)
             end
@@ -7809,7 +7825,13 @@ function GSE.ShowSequences()
                 treeStatus.groups["Sequences\001" .. tostring(lp[2]) .. "\001" .. tostring(lp[3])] = true
             end
         end
+        --@debug@
+        beforeTree = GSE.NowMs()
+        --@end-debug@
         editframe.ManageTree()
+        --@debug@
+        afterTree = GSE.NowMs()
+        --@end-debug@
         if GSE.GUI.SelectEditorTreePath then
             GSE.GUI.SelectEditorTreePath(editframe, selectPath)
         else
@@ -7836,7 +7858,7 @@ function GSE.ShowSequences()
     ReportOpenTiming(
         string.format("ShowSequences: %.0f ms (CreateEditor %.0f, ManageTree %.0f, select+show %.0f)",
             openTotal, afterCreate - openStartedAt,
-            afterTree - afterCreate, GSE.NowMs() - afterTree),
+            afterTree - beforeTree, GSE.NowMs() - afterTree),
         openTotal
     )
     --@end-debug@

--- a/GSE_GUI/Editor.lua
+++ b/GSE_GUI/Editor.lua
@@ -7715,7 +7715,11 @@ function GSE.ShowSequences()
     --@debug@
     local afterCreate = GSE.NowMs()
     --@end-debug@
-    editframe.ManageTree()
+    -- The tree build moved BELOW the expansion/selection restore: version
+    -- children are built lazily (versionsWanted reads the tree's expanded +
+    -- selected state), so building here -- before that state is restored --
+    -- gave the restored sequence a node with Configuration and New Version but
+    -- NO version children. The expand-click rebuild never fires on restore.
     --@debug@
     local afterTree = GSE.NowMs()
     --@end-debug@
@@ -7775,6 +7779,7 @@ function GSE.ShowSequences()
             -- Open to the detached tree's current node, silently: SetSelected loads
             -- the editor content via OnGroupSelected without expanding/RefreshTree.
             editframe.forceTreeSelection = true
+            editframe.ManageTree()
             if editframe.treeContainer.SetSelected then
                 editframe.treeContainer:SetSelected(srcStatus.selected)
             end
@@ -7797,7 +7802,14 @@ function GSE.ShowSequences()
             if lp[2] and lp[2] ~= "" then
                 treeStatus.groups["Sequences\001" .. tostring(lp[2])] = true
             end
+            -- Expand the restored SEQUENCE node itself: versionsWanted builds a
+            -- node's version children only when it is expanded or selected at
+            -- build time, and the selection has not happened yet.
+            if lp[3] and lp[3] ~= "" then
+                treeStatus.groups["Sequences\001" .. tostring(lp[2]) .. "\001" .. tostring(lp[3])] = true
+            end
         end
+        editframe.ManageTree()
         if GSE.GUI.SelectEditorTreePath then
             GSE.GUI.SelectEditorTreePath(editframe, selectPath)
         else


### PR DESCRIPTION
Fixes #2028

Opening the editor onto the restored sequence showed only **Configuration** and **New Version** — no version nodes. The lazy version children from #2014 are gated on `versionsWanted`, which reads the tree's expanded/selected state **at build time** — but `ShowSequences` built the tree *before* restoring that state, and the `OnGroupExpanded` rebuild only fires on a click, never on restore.

The build moves below the state restore, keeping exactly one build per open:

- normal path: the restored sequence node itself is marked expanded (segment 3 of the saved path) so its versions are wanted, then build, then select;
- detached-tree (adopted) path: build after mirroring the source tree's groups, before `SetSelected`.

### Testing

- `luac -p` clean.
- Confirmed in a running client: close + reopen restores the sequence with its version nodes present; expand-by-click behaviour unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)