### PR TITLE
#2031 Live X/255 counter measures the compiled length, like the Save gate

### DIFF
--- a/GSE_GUI/Editor.lua
+++ b/GSE_GUI/Editor.lua
@@ -7591,7 +7591,11 @@ function GSE.CreateEditor()
                         compiledMacro:SetText(body)
                         if compiledMacro.parent and compiledMacro.parent.DoLayout then compiledMacro.parent:DoLayout() end
                     end
-                    SetMacroCountText(macroEditBox, GSE.GetMacroEditorTextLength(value or ""))
+                    -- COMPILED length, same ruler as the over-limit backdrop and
+                    -- the Save gate (and as the draw-time count). Counting the raw
+                    -- display text here let the counter drop under 255 while the
+                    -- compiled body stayed over -- so Save "never un-greyed".
+                    SetMacroCountText(macroEditBox, GetCompiledMacroBodyLength(storedMacro))
                     FitMacroEditBoxToContent(macroEditBox, value)
                     UpdateMacroLimitState(macroEditBox, sequence.Versions[version].Actions[keyPath].macro, editframe, version)
                 end


### PR DESCRIPTION
Fixes #2031

The Save gate and the red over-limit backdrop measure the **compiled** body length (`TranslatorMode.String` — what WoW enforces), but the live X/255 counter measured the **raw display text**. Translated names run longer than what's typed, so the counter could drop under 255 while the compiled body stayed over — the gate correctly stayed shut and the counter lied about it. The draw-time counter already used the compiled length; the live path had diverged from #1998's stated intent ("report the COMPILED macro body length so the X/255 indicator matches the over-limit trigger").

One line: the live counter now uses `GetCompiledMacroBodyLength(storedMacro)` — one ruler for counter, red trigger, and Save gate. It may read higher than the raw typed text; that's the truthful number.

### Testing

- `luac -p` clean.
- Confirmed in a running client: push a block over 255 (red + Save greys), delete back — at ≤255 the red clears and Save re-enables on the same keystroke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)