### PR TITLE
#2033 Fit cache must match the frame, not just the last computation

### DIFF
--- a/GSE_GUI/Editor.lua
+++ b/GSE_GUI/Editor.lua
@@ -754,7 +754,17 @@ local function FitMacroEditBoxToContent(macroEditBox, text)
     local chrome =
         (macroEditBox.labelHeight or 12) + (macroEditBox.verticalOffset or 2) * 3 + MACRO_BOX_CHROME_SLACK
     local newHeight = math.ceil(textHeight + chrome)
-    if macroEditBox.gseFitHeight == newHeight then return end
+    -- The no-op check must also verify the FRAME still holds that height: a
+    -- later layout pass can shrink the frame while gseFitHeight remembers the
+    -- correct number, and then every subsequent fit -- typing included --
+    -- computed the same value, matched the cache, and returned without
+    -- repairing the frame. (Repro: the LAST block of a version drew at
+    -- baseline height and nothing would ever grow it.)
+    if macroEditBox.gseFitHeight == newHeight then
+        local frameHeight = macroEditBox.frame and macroEditBox.frame.GetHeight
+            and macroEditBox.frame:GetHeight() or 0
+        if math.abs(frameHeight - newHeight) < 1 then return end
+    end
     macroEditBox.gseFitHeight = newHeight
     local delta = newHeight - (macroEditBox.height or newHeight)
     macroEditBox:SetHeight(newHeight)


### PR DESCRIPTION
Fixes #2033

The last macro block of a version could draw at baseline height with its text clipped — and neither typing in the box nor reopening the version would fix it. `FitMacroEditBoxToContent` early-returns when a fit computes the same height as last time, but a later layout pass can shrink the box's **frame** while `gseFitHeight` remembers the correct number. From then on, every fit computes the same correct number, matches the cache, and returns without repairing the frame: stuck, no path back.

The no-op check now also verifies the frame's live height (within 1px) before returning, so a drifted frame gets re-applied — the fit is self-healing against any layout pass that resizes a box behind its back.

### Testing

- `luac -p` clean.
- Confirmed in a running client on the repro sequence: the last block (232/255, 7 lines) now opens at full height; typing and version switches behave normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)