### PR TITLE
#2023 Name version references as the author sees them; heal dangling ones

### DIFF
--- a/GSE/API/Storage.lua
+++ b/GSE/API/Storage.lua
@@ -1058,6 +1058,14 @@ local contextVersionPriority = {
 local contextVersionKeys = {}
 do
     local seen = {}
+    -- PVESolo is a version reference like any other -- the resolver reads it
+    -- for the solo context -- but it is NOT in contextVersionPriority (solo is
+    -- decided by isPVESoloContext, not by a flag entry). Left out of this list
+    -- it was invisible to BOTH the delete guard and the post-delete shifter, so
+    -- deleting the version the Solo row pointed at was allowed and left Solo
+    -- dangling at an index that no longer exists.
+    seen.PVESolo = true
+    contextVersionKeys[1] = "PVESolo"
     for _, entry in ipairs(contextVersionPriority) do
         if entry.valueKey and not seen[entry.valueKey] then
             seen[entry.valueKey] = true
@@ -1076,6 +1084,22 @@ end
 -- version that something points at is refused rather than silently repointed:
 -- an author who set Raid to version 4 chose that, and moving it to Default
 -- behind their back changes which macro fires in a raid.
+local contextKeyDisplayNames = {
+    -- Rowless rules, named for what they mean to the author.
+    Party    = "In a group",
+    Heroic   = "Heroic dungeons",
+    Mythic   = "Mythic dungeons",
+    -- Keys whose Configuration row is labelled differently from the key name.
+    PVESolo  = "Solo",
+    Scenario = "Delves/Scenarios",
+    MythicPlus = "Mythic+",
+    PVP      = "PvP Solo",
+}
+
+function GSE.ContextVersionKeyDisplayName(key)
+    return contextKeyDisplayNames[key] or key
+end
+
 function GSE.VersionReferencesInUse(metadata, version)
     local inUse = {}
     if type(metadata) ~= "table" then return inUse end
@@ -1083,9 +1107,42 @@ function GSE.VersionReferencesInUse(metadata, version)
     if not version then return inUse end
     if tonumber(metadata.Default) == version then inUse[#inUse + 1] = "Default" end
     for _, key in ipairs(contextVersionKeys) do
-        if tonumber(metadata[key]) == version then inUse[#inUse + 1] = key end
+        if tonumber(metadata[key]) == version then
+            inUse[#inUse + 1] = GSE.ContextVersionKeyDisplayName(key)
+        end
     end
     return inUse
+end
+
+--- Repair references that point past the end of the version list.
+---
+--- Data already broken before PVESolo joined contextVersionKeys can carry a
+--- reference to a version that no longer exists (deleting the version the Solo
+--- row pointed at was allowed, and the shifter did not touch it). The resolver
+--- would then select a missing version. Anything out of range falls back to
+--- the Default, which is the behaviour an unset context already has.
+--- Returns the list of repaired display names.
+function GSE.RepairDanglingVersionReferences(sequence)
+    local repaired = {}
+    if type(sequence) ~= "table" then return repaired end
+    local metadata, versions = sequence.MetaData, sequence.Versions
+    if type(metadata) ~= "table" or type(versions) ~= "table" then return repaired end
+    local count = #versions
+    if count < 1 then return repaired end
+
+    local default = tonumber(metadata.Default)
+    if default and not versions[default] then
+        metadata.Default = 1
+        repaired[#repaired + 1] = "Default"
+    end
+    for _, key in ipairs(contextVersionKeys) do
+        local value = tonumber(metadata[key])
+        if value and not versions[value] then
+            metadata[key] = nil
+            repaired[#repaired + 1] = GSE.ContextVersionKeyDisplayName(key)
+        end
+    end
+    return repaired
 end
 
 --- Move every version reference down one slot after `version` was deleted.

--- a/GSE/Localization/ModL_enUS.lua
+++ b/GSE/Localization/ModL_enUS.lua
@@ -946,6 +946,9 @@ L["Specialisation / Class ID"] = true
 -- key-as-value fallback.
 L["This is a common WoW setting used by all addons; it controls when your action buttons respond.  On: they react when you press the key (key-down).  Off: they react when you release it (key-up).  GSE now works either way -- Actionbar Overrides and keybinds fire a single step in both states.  With this on, GSE keybinds also fire on key-down for a faster response.  Changes apply immediately out of combat (or on your next rebind if toggled mid-combat)."] = true
 L["Version %d is in use by: %s.  Point %s at another version on the Configuration tab before deleting this one."] = true
+L["Version %d is in use by: %s.  Point %s at another version before deleting this one."] = true
+L["%s pointed at a version that no longer exists and now follows the Default.  Save to keep this."] = true
+L["%s now follow the Default version."] = true
 L["it"] = true
 L["them"] = true
 L["Announce Manual Sequence Resets"] = true

--- a/GSE_GUI/Editor.lua
+++ b/GSE_GUI/Editor.lua
@@ -6229,7 +6229,7 @@ function GSE.CreateEditor()
                 if #blocking > 0 then
                     GSE.Print(
                         string.format(
-                            L["Version %d is in use by: %s.  Point %s at another version on the Configuration tab before deleting this one."],
+                            L["Version %d is in use by: %s.  Point %s at another version before deleting this one."],
                             version,
                             table.concat(blocking, ", "),
                             #blocking == 1 and L["it"] or L["them"]
@@ -6260,6 +6260,13 @@ function GSE.CreateEditor()
 
                     table.remove(sequence.Versions, version)
 
+                    -- After the removal and the renumber, ANY reference still
+                    -- pointing outside the list falls back to the Default, so a
+                    -- row can never display (or resolve to) a version that no
+                    -- longer exists.
+                    local repaired = GSE.RepairDanglingVersionReferences
+                        and GSE.RepairDanglingVersionReferences(sequence) or {}
+
                     -- Mirror the deletion into the Library display cache so the
                     -- tree drops the version node immediately, before any Save
                     -- (GSESequences is only written on explicit Save). The tree is
@@ -6281,9 +6288,28 @@ function GSE.CreateEditor()
                         end
                     end
 
+                    if #repaired > 0 then
+                        GSE.Print(
+                            string.format(
+                                L["%s now follow the Default version."],
+                                table.concat(repaired, ", ")
+                            ),
+                            Statics.DebugModules["Editor"]
+                        )
+                    end
                     printtext = printtext .. " " .. L["This change will not come into effect until you save this sequence."]
                     editframe.ManageTree()
-                    treeContainer:SelectByValue(path)
+                    -- Re-select the CONFIG node, not `path`: path points at the
+                    -- version just deleted, so re-selecting it left the panel
+                    -- showing stale dropdown values (rows still displaying a
+                    -- version that no longer exists). The config page redraws
+                    -- from the repaired metadata.
+                    local reselect = path
+                    local parts = {("\001"):split(path or "")}
+                    if #parts >= 3 then
+                        reselect = table.concat({parts[1], parts[2], parts[3]}, "\001") .. "\001config"
+                    end
+                    treeContainer:SelectByValue(reselect)
                     editframe:SetStatusText(string.format(printtext, version))
                     C_Timer.After(
                         5,
@@ -7997,6 +8023,21 @@ function GSE.GUILoadEditor(editor, key, recordedstring)
 
     if GSE.isEmpty(sequence.WeakAuras) then
         sequence.WeakAuras = {}
+    end
+    -- Heal references left pointing at a version that no longer exists (the
+    -- Solo row could do this before PVESolo was guarded). They fall back to the
+    -- Default; tell the author what changed so a silent edit never happens.
+    if GSE.RepairDanglingVersionReferences then
+        local repaired = GSE.RepairDanglingVersionReferences(sequence)
+        if #repaired > 0 then
+            GSE.Print(
+                string.format(
+                    L["%s pointed at a version that no longer exists and now follows the Default.  Save to keep this."],
+                    table.concat(repaired, ", ")
+                ),
+                Statics.DebugModules["Editor"]
+            )
+        end
     end
     editor:SetStatusText("GSE: " .. GSE.VersionString)
     editor.SequenceName = sequenceName

--- a/spec/versionrefs_spec.lua
+++ b/spec/versionrefs_spec.lua
@@ -48,14 +48,17 @@ describe(
               seen[k] = true
             end
             -- PVP routes to Arena in one priority entry and to PVP in another;
-            -- both names must still be offered exactly once each.
+            -- both names must still be offered exactly once each. PVESolo is
+            -- not in the priority table (solo is the absence of every flag)
+            -- but is a version reference the resolver reads, so the guard and
+            -- the renumber must see it too.
             for _, expected in ipairs({
-              "Scenario", "Arena", "PVP", "Raid", "Mythic",
+              "PVESolo", "Scenario", "Arena", "PVP", "Raid", "Mythic",
               "MythicPlus", "Heroic", "Dungeon", "Timewalking", "Party",
             }) do
               assert.is_true(seen[expected] == true, "missing key " .. expected)
             end
-            assert.equals(10, #keys)
+            assert.equals(11, #keys)
           end
         )
       end
@@ -89,6 +92,18 @@ describe(
             table.sort(inUse)
             assert.equals("Arena", inUse[1])
             assert.equals("Raid", inUse[2])
+          end
+        )
+        it(
+          "reports keys by their Configuration row label, not the raw key",
+          function()
+            local meta = {Default = 1, PVESolo = 3, Party = 3, Scenario = 3}
+            local inUse = GSE.VersionReferencesInUse(meta, 3)
+            assert.equals(3, #inUse)
+            table.sort(inUse)
+            assert.equals("Delves/Scenarios", inUse[1])
+            assert.equals("In a group", inUse[2])
+            assert.equals("Solo", inUse[3])
           end
         )
         it(
@@ -194,6 +209,43 @@ describe(
             -- A mirror write into the Library must not touch the editor's copy.
             table.insert(stored.Versions, {Actions = {}})
             assert.equals(1, #seq.Versions)
+          end
+        )
+      end
+    )
+    describe(
+      "GSE.RepairDanglingVersionReferences",
+      function()
+        it(
+          "moves references outside the version list back to the Default",
+          function()
+            local seq = {
+              MetaData = {Default = 1, PVESolo = 2, Raid = 5},
+              Versions = {{}, {}}
+            }
+            local repaired = GSE.RepairDanglingVersionReferences(seq)
+            assert.equals(1, #repaired)
+            assert.equals("Raid", repaired[1])
+            assert.is_nil(seq.MetaData.Raid)
+            assert.equals(2, seq.MetaData.PVESolo)
+          end
+        )
+        it(
+          "repairs a dangling Default to version 1",
+          function()
+            local seq = {MetaData = {Default = 9}, Versions = {{}}}
+            local repaired = GSE.RepairDanglingVersionReferences(seq)
+            assert.equals(1, #repaired)
+            assert.equals("Default", repaired[1])
+            assert.equals(1, seq.MetaData.Default)
+          end
+        )
+        it(
+          "is safe on rubbish input",
+          function()
+            assert.equals(0, #GSE.RepairDanglingVersionReferences(nil))
+            assert.equals(0, #GSE.RepairDanglingVersionReferences({}))
+            assert.equals(0, #GSE.RepairDanglingVersionReferences({MetaData = {}, Versions = {}}))
           end
         )
       end


### PR DESCRIPTION
Fixes #2023.

Redone per the review of the previous attempt (#2025): the message now points at the thing the author can act on, and nothing is cleared behind their back.

## What changed

**Names match what the author sees.** The delete-block message reports each context by its Configuration row label — Solo, Delves/Scenarios, Mythic+, PvP Solo — and the three rules with no row of their own by what they mean: `Party` → **In a group** (it is the exact complement of the Solo row — `isPVESoloContext` is false whenever `inParty` is true), `Heroic` → **Heroic dungeons**, `Mythic` → **Mythic dungeons**. The "on the Configuration tab" instruction is gone, since for those three there is no row to find there.

**`PVESolo` joins `contextVersionKeys`.** It is a version reference the resolver reads for the solo context, but it was invisible to both the delete guard and the post-delete renumber — so deleting the version the Solo row pointed at was allowed, and Solo was left pointing at an index that no longer exists.

**Dangling references heal to the Default.** `GSE.RepairDanglingVersionReferences` moves any reference pointing outside the version list back to the Default, and says so in chat. It runs on editor load (healing data already broken by the `PVESolo` gap) and again after a version delete, so a row can never display — or resolve to — a version that does not exist.

**The panel redraws after a delete.** The delete handler re-selected the tree node it had just deleted, so the Config page kept showing stale dropdown values. It now re-selects the Configuration node, which redraws from the repaired metadata.

## Tested in-game (Retail)

- Deleting a referenced version is blocked naming the rows as labelled, e.g. `Version 2 is in use by: Solo, Delves/Scenarios.`
- With Solo alone on the version, the delete is blocked (previously allowed — the `PVESolo` gap).
- After repointing rows and deleting, the panel immediately shows the surviving versions, and the state survives Save + `/reload`.
- Opening a sequence with an already-dangling reference repairs it with a chat report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)