### PR TITLE
#2036 Match the Global node's real tree path so its versions build

### DIFF
--- a/GSE_GUI/Editor_Tree.lua
+++ b/GSE_GUI/Editor_Tree.lua
@@ -1482,7 +1482,14 @@ local function ManageTree(editframe)
         local elements = GSE.split(k, ",")
         local tclassid = tonumber(elements[1])
         local specid = tonumber(elements[2])
-        local nodePath = "Sequences\001" .. tostring(tclassid) .. "\001" .. k
+        -- The Global class node tree value is the string "GLOBAL", not 0, so
+        -- the runtime path of its sequences is Sequences\001GLOBAL\001<k>.
+        -- Deriving the path from the classid built Sequences\0010\001<k> instead,
+        -- which never matched the expanded/selected state: Global sequences
+        -- never got version children, and (with the guard below) expanding
+        -- could not repair it either.
+        local pathClass = tclassid == 0 and "GLOBAL" or tostring(tclassid)
+        local nodePath = "Sequences\001" .. pathClass .. "\001" .. k
         local wantVersions = versionsWanted(nodePath)
         if tclassid and GSE.isEmpty(classtree[tclassid]) then
             classtree[tclassid] = {}
@@ -1646,7 +1653,7 @@ local function ManageTree(editframe)
             if not (expanded and path) then return end
             local parts = {("\001"):split(path)}
             if parts[1] ~= "Sequences" or #parts ~= 3 then return end
-            if not tonumber(parts[2]) then return end
+            if not tonumber(parts[2]) and parts[2] ~= "GLOBAL" then return end
             -- Rebuild unconditionally. The first cut of this skipped the rebuild
             -- when the sequence was already in GSE.Library, on the reasoning
             -- that a loaded sequence must already have had its versions drawn.


### PR DESCRIPTION
Fixes #2036.

Global sequences expanded to Configuration + New Version with no version children, and expanding could not repair it. Two sites, one mismatch:

- `versionsWanted` derived its lookup path from the numeric classid (`Sequences\0010\001<key>`), but the Global node's tree value is the string `GLOBAL`, so the real path is `Sequences\001GLOBAL\001<key>` — the expanded/selected state never matched. The path segment now comes from the node's actual value (`GLOBAL` for classid 0).
- The `OnGroupExpanded` rebuild handler rejected any second segment that is not a number, so the expand-click rebuild bailed for Global sequences. `GLOBAL` is now let through.

Class sequences were unaffected because their tree value and classid coincide.

Tested in-game (Retail): Global sequences show their versions on restore-open and on expand-click; class sequences unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)