### PR TITLE
#2038 Bracket-index the Implementation Link when the name is not an identifier

### DIFF
--- a/GSE_GUI/Editor_Variable.lua
+++ b/GSE_GUI/Editor_Variable.lua
@@ -14,6 +14,22 @@ if GSE.isEmpty(GSE.GUI) then GSE.GUI = {} end
 -- shows barely two wrapped lines once the panel's own padding is taken out.
 local INLINE_NOTES_PANEL_HEIGHT = 120
 
+-- The Implementation Link is what the author pastes into a macro block, so it
+-- has to be valid Lua for ANY name they gave the variable. Built by blind
+-- concatenation as =GSE.V.<name>(), a name that is not a bare identifier --
+-- "SLG-SBAssist-LvL" -- came out as =GSE.V.SLG-SBAssist-LvL(), which parses as
+-- subtraction ending in a nil call, throws, and is swallowed as a missing
+-- variable: the editor's Current Value box worked (it indexes GSE.V[name])
+-- while the sequence produced nothing. Bracket-index anything that is not a
+-- valid identifier, the way GSE already references variables internally.
+local function VariableImplementationLink(name)
+    name = tostring(name or "")
+    if name:match("^[%a_][%w_]*$") then
+        return "=GSE.V." .. name .. "()"
+    end
+    return "=GSE.V['" .. name:gsub("'", "\\'") .. "']()"
+end
+
 local function SetEditBoxLabelGap(widget, gap)
     if not (widget and widget.label and widget.editBox and widget.frame) then return end
     local labelHeight = widget.label:GetStringHeight()
@@ -86,7 +102,7 @@ end]],
     keyEditBox:SetCallback(
         "OnTextChanged",
         function(self, event, text)
-            local implementationText = [[=GSE.V.]] .. text .. [[()]]
+            local implementationText = VariableImplementationLink(text)
             implementation:SetText(implementationText)
         end
     )
@@ -366,7 +382,7 @@ end]],
     implementation:SetHeight(32)
     implementation:DisableButton(true)
     SetEditBoxLabelGap(implementation, 2)
-    local implementationText = [[=GSE.V.]] .. name .. [[()]]
+    local implementationText = VariableImplementationLink(name)
     implementation:SetText(implementationText)
 
     local currentOutput = UI:Create("EditBox")


### PR DESCRIPTION
Fixes #2038.

The Implementation Link was built by concatenation as `=GSE.V.<name>()`. For a name that is not a bare Lua identifier that link does not reference the variable — `SLG-SBAssist-LvL` yields `=GSE.V.SLG-SBAssist-LvL()`, which is *valid* Lua meaning `GSE.V.SLG - SBAssist - LvL()`. It is therefore not caught as malformed: it fails at runtime with `attempt to perform arithmetic on a nil value (field 'SLG')`, which is swallowed, so the block silently produces nothing.

Both build sites — `:89` (live, as the name is typed) and `:369` (initial render) — now go through one helper that emits dot syntax for a valid identifier and bracket syntax otherwise. That matches how GSE already references variables everywhere else: `GSE.BooleanVariables` keys (`Storage.lua:797`), the QoL Tab menu insertions (`QoL.lua:319/996/1023/1170`), and the editor's own Current Value box (`Editor_Variable.lua:391`) — which is why the preview showed the right value while the copied link did nothing.

Names with an apostrophe are escaped, so the emitted link stays parseable.

Verified against the Lua parser for identifiers, hyphens, spaces, leading digits, empty and apostrophe names, and in-game: the link for a hyphenated variable now returns its value when pasted into a macro block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)