### PR TITLE
#2040 Build version children for any loaded sequence, not only path-matched ones

### DIFF
--- a/GSE_GUI/Editor_Tree.lua
+++ b/GSE_GUI/Editor_Tree.lua
@@ -1560,7 +1560,14 @@ local function ManageTree(editframe)
             node.text = "|cFFFF3030" .. tostring(elements[3]) .. " |r"
             node.icon = "Interface\\DialogFrame\\UI-Dialog-Icon-AlertNew"  -- swap for any flag texture
         else
-            if loadedSeq and wantVersions then
+            -- Build version children for ANY sequence already in memory. The
+            -- expensive half of laziness is the decompress above (still gated
+            -- on wantVersions); assembling children for a record already in the
+            -- Library is a few table inserts. Gating the children on the tree
+            -- path too left a just-created sequence showing Configuration and
+            -- New Version with nothing between them, because it is neither
+            -- expanded nor selected at the moment ManageTree runs.
+            if loadedSeq then
                 for i, j in ipairs(loadedSeq.Versions) do
                     table.insert(node.children, {
                         value = i,


### PR DESCRIPTION
Fixes #2040.

`versionsWanted` gates a node's version children on the tree's expanded/selected state at build time. `GUICreateNewSequence` puts the record in `GSE.Library` and then calls `ManageTree()` — but the new node is neither expanded nor selected at that moment (its `SelectByValue` runs after the build), so nothing matched and the sequence showed **Configuration** and **New Version** with no versions between them until the editor was closed and reopened.

The load is the expensive half of the laziness and stays gated: `GSE.EnsureSequenceLoaded` still only runs when `wantVersions` is true, so a tree build still does not decompress sequences nobody is looking at. Building children for a record that is *already* in `GSE.Library` costs a few table inserts, so that no longer asks the tree path for permission.

Tested in-game (Retail): a newly created sequence shows `1 - default` immediately; restored and Global sequences still show their versions; the open is not measurably slower.

🤖 Generated with [Claude Code](https://claude.com/claude-code)