### PR TITLE
#2044 ApplyShowTooltipToAction must rawget: the Actions array carries the path metatable

### DIFF
--- a/GSE/API/StringFunctions.lua
+++ b/GSE/API/StringFunctions.lua
@@ -177,13 +177,17 @@ end
 --- meaningful and must survive.
 function GSE.ApplyShowTooltipToAction(action)
     if type(action) ~= "table" then return false end
-    if action.Type ~= Statics.Actions.Action and action.Type ~= Statics.Actions.Repeat then
+    -- rawget: the editor puts Statics.TableMetadataFunction on the Actions
+    -- array, and that __index only understands table (path) keys -- a plain
+    -- string key errors inside ipairs.
+    local actionType = rawget(action, "Type")
+    if actionType ~= Statics.Actions.Action and actionType ~= Statics.Actions.Repeat then
         return false
     end
 
     local changed = false
     for _, key in ipairs({"macro", "macrotext"}) do
-        local body = action[key]
+        local body = rawget(action, key)
         if type(body) == "string" and body ~= "" then
             local stripped, argument, found = GSE.SplitShowTooltipDirectives(body)
             if found then

--- a/spec/stringfunctions_spec.lua
+++ b/spec/stringfunctions_spec.lua
@@ -253,6 +253,17 @@ helpTxt = 'Talents: 3331222',]]
         )
 
         it(
+          "walks an Actions array carrying the editor's path metatable without erroring",
+          function()
+            -- The editor sets Statics.TableMetadataFunction on Versions[n].Actions;
+            -- its __index only understands table (path) keys, so a plain
+            -- `actions.Type` lookup dies inside ipairs on the game's Lua 5.1.
+            local actions = setmetatable({{Type = "Action", type = "macro", macro = "/cast Sunfire"}}, GSE.Static.TableMetadataFunction)
+            assert.is_false(GSE.ApplyShowTooltipToAction(actions))
+          end
+        )
+
+        it(
           "does not re-flag an icon the user picked themselves",
           function()
             GSE.GetShowTooltipIconInfo = function() return {name = "Sunfire", iconID = 535045} end


### PR DESCRIPTION
Fixes the save error introduced with #2044:

```
GSE/API/Statics.lua:504: bad argument #1 to 'ipairs' (table expected, got string)
[GSE/API/StringFunctions.lua]:180: in function 'ApplyShowTooltipToAction'
[GSE/API/StringFunctions.lua]:266: in function 'SanitizeSequenceEditorMarkup'
[GSE/API/Storage.lua]:560: in function 'ReplaceSequence'
Locals: t={ 1=<table> }  k="Type"
```

`SanitizeSequenceEditorMarkup` walks every table in the sequence and now calls `ApplyShowTooltipToAction` on each. The editor puts `Statics.TableMetadataFunction` on `Versions[n].Actions`, and that `__index` only understands table (path) keys — so the plain `action.Type` on the Actions array itself lands in `ipairs("Type")`. `Editor.lua` already rawgets past this metatable for the same reason (the comment at the `rawget` near line 6487).

Fix: `rawget` for `Type` and the two macro-body keys. No data-model change.

Spec: an Actions array carrying the metatable returns `false` without erroring. On the previous code, under a 5.1-strict `ipairs`, it fails with the exact in-game message; the suite passes with the fix.

Verified in-game (2026-09-02): after /reload, saving a Hunter sequence that had errored succeeds; a create + rename + save cycle also completes with the "gse.tools ID will remain the same" notice and no error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
