### PR TITLE
#2048 Size the macro box from the editbox's rendered height, not only the meter

### DIFF
--- a/GSE_GUI/Editor.lua
+++ b/GSE_GUI/Editor.lua
@@ -603,7 +603,7 @@ local MACRO_BOX_BASE_LINES = 5
 -- clamps the inner editbox to (updateEditBoxSize). At a small chat font the
 -- min-row fit lands under that floor and the bottom row would render outside
 -- the visible scroll area, so the frame is never asked for less.
-local MACRO_BOX_CHROME_SLACK = 6
+local MACRO_BOX_CHROME_SLACK = 2
 local MACRO_BOX_MIN_INNER = 40
 -- Rows -> pixels in the box's OWN font: a row is the measured line height, and
 -- every row after the first also carries the editbox's line spacing.
@@ -728,6 +728,14 @@ local function FitMacroEditBoxToContent(macroEditBox, text)
     if oneRow <= 0 then oneRow = fontSize or 14 end
     meter:SetText(body ~= "" and body or "X")
     local textHeight = meter:GetStringHeight() or oneRow
+    -- The meter is an estimate; the editbox is the truth. It is the scroll
+    -- child and sizes itself to its own rendered text, and it wraps lines the
+    -- meter does not (measured: a 4-line block the meter called 4 rows at 548px
+    -- rendered at 5 -- ebH 69 against a 66px visible area, last line cut).
+    -- Take whichever is taller: the box must never be shorter than what the
+    -- editbox actually draws.
+    local rendered = eb.GetHeight and eb:GetHeight() or 0
+    if rendered > textHeight then textHeight = rendered end
     if typingOnTrailingRow then textHeight = textHeight + oneRow + spacing end
     -- The box fits its content, so its scrollbar is dead weight: hide it. (A
     -- 255-char block cannot realistically reach the row cap; one that did needs


### PR DESCRIPTION
Fixes #2048.

Any block with a line long enough to wrap lost its last row. The fit sizes the box from a hidden FontString meter, and the meter under-counts: for a 4-line block it reports 4 rows at 548px while the editbox renders 5 (`ebH=69` = 5 × 13.8 against a 66px visible area). Same width, same font — the editbox wraps a line the meter does not.

The editbox is the scroll child and sizes itself to its own rendered text, so its height is the truth. The fit now takes the taller of the meter and the editbox: a box can never be built shorter than what the editbox actually draws. Three lines in `FitMacroEditBoxToContent`.

`MACRO_BOX_CHROME_SLACK` drops 6 → 2. Measured on the live boxes: the frame spends 18px on label and offsets while the chrome budgeted 24, so the extra 6 was insurance against the meter — and showed as a spare half-row under every block that did not wrap.

Nothing else changes: no layout, hook, timer or frame-level work, only the height number the existing fit computes.

Tested in-game (Retail): wrapped-line blocks show their last line; plain blocks lose the spare half-row; clicking into boxes, typing, and Enter at the end of a block all unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)