### PR TITLE
#2052 Restore the pooled EditBox character cap on reuse

### DIFF
--- a/GSE_GUI/NativeUI.lua
+++ b/GSE_GUI/NativeUI.lua
@@ -5946,6 +5946,10 @@ local function snapshotPristine(widget)
     widget.__gsePristineTexts = texts
     widget.__gsePristineKeys = keys
     widget.__gsePristineScripts = scripts
+    local pEb = widget.editBox or widget.editbox
+    if pEb and pEb.GetMaxLetters then
+        widget.__gsePristineMaxLetters = pEb:GetMaxLetters() or 0
+    end
     widget.__gsePristineW, widget.__gsePristineH = widget.frame:GetSize()
     keys.__gsePristineKeys, keys.__gsePristineScripts = true, true
     keys.__gsePristineW, keys.__gsePristineH = true, true
@@ -5995,6 +5999,14 @@ local function resetForReuse(widget)
     if eb then
         if eb.ClearFocus then pcall(eb.ClearFocus, eb) end
         if eb.SetText then pcall(eb.SetText, eb, "") end
+        -- Restore the character cap. A caller that narrowed it (the loop-limit
+        -- box is SetMaxLetters(4)) left that cap on the pooled widget for the
+        -- rest of the session, so the next consumer -- the Spell field, say --
+        -- silently truncated everything to four characters. 0 is Blizzard's
+        -- "no limit", which is what a freshly created EditBox has.
+        if eb.SetMaxLetters then
+            pcall(eb.SetMaxLetters, eb, widget.__gsePristineMaxLetters or 0)
+        end
     end
     if widget.label and widget.label.SetText then pcall(widget.label.SetText, widget.label, "") end
     if widget.text and widget.text ~= widget.label and widget.text.SetText then


### PR DESCRIPTION
Fixes #2052.

An Action block set to **Spell** truncated the spell name to four characters — `Growl` stored as `Grow` — whether the name came from the Tab menu or was typed.

The Tab menu is not involved: it calls `spellEditBox:SetText(value)` (`Editor.lua:7731`) and WoW truncates silently at the edit box's character cap. The cap came from a different field via the widget pool — the loop-limit box narrows its EditBox with `SetMaxLetters(4)` (`Editor.lua:5763`), and `resetForReuse` never restored it. Once a widget had served as the loop-limit box it kept that 4-character cap for the rest of the session, and whichever field the pool handed it to next truncated.

Same family as #2024 (text colour, enabled state) and #2020 (styling, subframe art, frame flags): per-widget state a caller mutated and the pool did not put back.

The fix snapshots `maxLetters` alongside the existing pristine state and restores it in `resetForReuse`, defaulting to 0 — Blizzard's "no limit", the value a freshly created EditBox has. Both calls are `pcall`-guarded and feature-checked, consistent with the surrounding restores.

Tested in-game (Retail): with a Loop block present so the loop-limit widget is created and released, a Spell field now keeps the full name from the Tab menu and from typing. Loop limit still caps at 4. Note that names already truncated before the fix stay truncated in stored data and need re-picking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)