### PR TITLE
#2054 Keep a packed sequence packed at rest instead of rewriting it plain

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -104,6 +104,7 @@ globals = {
     "GSESequences",
     "GSESupportReports",
     "GSEDeltas",
+    "GSERepackQueue",
     "GSE_GUI",
     "GSE_C",
     "GSESpellCache",

--- a/GSE/API/Codec.lua
+++ b/GSE/API/Codec.lua
@@ -81,27 +81,4 @@ function GSE.DecodePackedMessage(data)
     return C_EncodingUtil.DeserializeCBOR(C_EncodingUtil.DecompressString(plain))
 end
 
-local DEFAULT_KEY_ID = "1"
-
-local function randomNonce()
-    local t = {}
-    for i = 1, 12 do t[i] = schar(math.random(0, 255)) end
-    return concat(t)
-end
-
---- Inverse of GSE.DecodePackedMessage. Identical layout:
----   "!GSE3!+" .. keyid .. base64( nonce[12] .. chacha20(key, nonce, 0, deflate(cbor(tab))) )
---- ChaCha20 is a stream cipher, so TransformBytes both encrypts and decrypts;
---- this is the same call DecodePackedMessage makes, in the other direction.
---- Lives here because `keys` is file-local.
-function GSE.EncodePackedMessage(tab, keyid)
-    keyid = keyid or DEFAULT_KEY_ID
-    local key = keys[keyid]
-    if not key then error("unsupported encoding") end
-    local plain = C_EncodingUtil.CompressString(C_EncodingUtil.SerializeCBOR(tab))
-    local nonce = randomNonce()
-    local body = GSE.TransformBytes(key, nonce, 0, plain)
-    return "!GSE3!+" .. keyid .. C_EncodingUtil.EncodeBase64(nonce .. body)
-end
-
 if type(GSE.DebugProfile) == "function" then GSE.DebugProfile("Codec") end

--- a/GSE/API/Codec.lua
+++ b/GSE/API/Codec.lua
@@ -81,4 +81,27 @@ function GSE.DecodePackedMessage(data)
     return C_EncodingUtil.DeserializeCBOR(C_EncodingUtil.DecompressString(plain))
 end
 
+local DEFAULT_KEY_ID = "1"
+
+local function randomNonce()
+    local t = {}
+    for i = 1, 12 do t[i] = schar(math.random(0, 255)) end
+    return concat(t)
+end
+
+--- Inverse of GSE.DecodePackedMessage. Identical layout:
+---   "!GSE3!+" .. keyid .. base64( nonce[12] .. chacha20(key, nonce, 0, deflate(cbor(tab))) )
+--- ChaCha20 is a stream cipher, so TransformBytes both encrypts and decrypts;
+--- this is the same call DecodePackedMessage makes, in the other direction.
+--- Lives here because `keys` is file-local.
+function GSE.EncodePackedMessage(tab, keyid)
+    keyid = keyid or DEFAULT_KEY_ID
+    local key = keys[keyid]
+    if not key then error("unsupported encoding") end
+    local plain = C_EncodingUtil.CompressString(C_EncodingUtil.SerializeCBOR(tab))
+    local nonce = randomNonce()
+    local body = GSE.TransformBytes(key, nonce, 0, plain)
+    return "!GSE3!+" .. keyid .. C_EncodingUtil.EncodeBase64(nonce .. body)
+end
+
 if type(GSE.DebugProfile) == "function" then GSE.DebugProfile("Codec") end

--- a/GSE/API/SequenceDelta.lua
+++ b/GSE/API/SequenceDelta.lua
@@ -333,6 +333,55 @@ function GSE.StoreDeltaFork(element)
     return true
 end
 
+--- Reconstruct `obj` from its stored delta fork, or nil when it has none.
+--
+-- The stored blob is only ever the STARTING POINT for content that has been
+-- edited locally; GSEDeltas holds the divergence. A load path that assigned
+-- the decoded blob straight into the Library would silently discard the edit,
+-- so every load path asks this first and prefers what it returns.
+function GSE.ApplyStoredDeltaFork(obj)
+    if type(GSEDeltas) ~= "table" or type(obj) ~= "table" then return nil end
+    local meta = obj.MetaData or {}
+    local pid = meta.PlatformID or obj.PlatformID
+    if type(pid) ~= "string" or type(GSEDeltas[pid]) ~= "table" then return nil end
+    return GSE.ReconstructDeltaFork(GSEDeltas[pid])
+end
+
+--- Open a delta fork for content that does not have one yet, keyed by its own
+--- PlatformID, using the stored blob as the base.
+--
+-- The base is carried across VERBATIM, and that is the entire point: for
+-- protected content the packed !GSE3!+ blob moves into `b` still sealed. The
+-- reconstruct side already copes, because it reads the base through
+-- GSE.DecodeMessage, which dispatches the packed envelope to
+-- DecodePackedMessage. So an edit to protected content can be persisted
+-- without the addon ever producing an envelope.
+--
+-- Only the divergence lands in `d`, and DiffDelta emits untouched blocks as
+-- {from = n} back-references rather than copies, so the delta carries what the
+-- user actually typed and not the protected body around it.
+--
+-- `src` is the upstream this diverged from. Editing in place rather than
+-- forking to a new identity means that is the record's own id: "this content,
+-- changed locally". Returns false when there is no PlatformID to key by --
+-- the caller then falls back to a repack request.
+function GSE.SeedDeltaFork(baseBlob, obj, contentType)
+    if type(obj) ~= "table" or type(baseBlob) ~= "string" then return false end
+    local meta = obj.MetaData or {}
+    local pid = meta.PlatformID or obj.PlatformID
+    if type(pid) ~= "string" or pid == "" then return false end
+    if type(GSEDeltas) ~= "table" then GSEDeltas = {} end
+    -- Already forked: this is just another edit on top.
+    if type(GSEDeltas[pid]) == "table" then return GSE.UpdateDeltaFork(obj) end
+    local ok, decoded = GSE.DecodeMessage(baseBlob)
+    if not ok or type(decoded) ~= "table" then return false end
+    local base = decoded[2] or decoded
+    local d = GSE.EncodeDelta(GSE.DiffDelta(base, obj))
+    if type(d) ~= "string" then return false end
+    GSEDeltas[pid] = {b = baseBlob, d = d, t = contentType or "sequence", src = pid}
+    return true
+end
+
 function GSE.UpdateDeltaFork(obj)
     if type(GSEDeltas) ~= "table" or type(obj) ~= "table" then return false end
     local meta = obj.MetaData or {}

--- a/GSE/API/Serialisation.lua
+++ b/GSE/API/Serialisation.lua
@@ -9,6 +9,44 @@ function GSE.EncodeMessage(tab)
         return result
 end
 
+--- True when a stored blob carries the packed (!GSE3!+) envelope.
+--
+-- GSE decrypts this envelope so it can run the macro; it never produces one.
+-- The key ships in Codec.lua and is symmetric, so anything that could seal
+-- content here could be lifted wholesale, and a stream cipher under one fixed
+-- key is unforgiving of a weak nonce. Sealing stays with gse.tools, which is
+-- the only party that has somewhere safe to do it.
+function GSE.IsPackedBlob(blob)
+    return type(blob) == "string" and string.sub(blob, 1, 7) == "!GSE3!+"
+end
+
+--- True when a decoded body is protected content -- a copy gse.tools sent to
+-- someone who does not own it. Accepts the bare object or the {name, object}
+-- tuple sequences are stored as.
+function GSE.IsProtectedContent(obj)
+    if type(obj) ~= "table" then return false end
+    local meta = obj.MetaData
+    if type(meta) ~= "table" and type(obj[2]) == "table" then meta = obj[2].MetaData end
+    return type(meta) == "table" and meta.noExport and true or false
+end
+
+--- The gate every at-rest write consults. True means "leave the stored blob
+-- exactly as it is".
+--
+-- Two ways in. The blob on disk is already packed, so rewriting it plain would
+-- strip the envelope -- the bug in #2054. Or the body says noExport, so it is
+-- protected content that must not be written in the clear even if a shipped
+-- build already downgraded it.
+--
+-- Callers do not lose anything by honouring this. Every at-rest write GSE makes
+-- to protected content persists a DERIVED value -- the OriginKey stamp, the
+-- macrotext rename migration, editor-markup sanitisation, a nil'd checksum, a
+-- resolved icon -- and every one of them is recomputed from the body on the
+-- next load. Real edits take the delta path instead; see GSE.ReplaceSequence.
+function GSE.IsProtectedAtRest(blob, obj)
+    return GSE.IsPackedBlob(blob) or GSE.IsProtectedContent(obj)
+end
+
 -- This decodes a string into a LUA Table.  This returns a bool (success) and an object that contains the results.
 function GSE.DecodeMessage(data)
     if string.sub(data, 1, 7) == "!GSE3!+" then

--- a/GSE/API/Serialisation.lua
+++ b/GSE/API/Serialisation.lua
@@ -10,6 +10,58 @@ function GSE.EncodeMessage(tab)
 end
 
 -- This decodes a string into a LUA Table.  This returns a bool (success) and an object that contains the results.
+--- Encode for STORAGE (GSESequences / GSEVariables).
+---
+--- The envelope follows ONE fact: is this protected content (MetaData.noExport,
+--- set by gse.tools on copies sent to someone who does not own them). It is NOT
+--- inherited from whatever was on disk -- inheriting makes the envelope sticky,
+--- so a blob packed by an over-broad build could never return to plain.
+---
+--- Protected content is packed; the author's OWN content stays plain, on
+--- purpose. The GSE Companion desktop app decodes GSE.lua directly and is
+--- deliberately blind to !GSE3!+ ("opaque to the Companion by design -- no
+--- key", wow.js:438). Packing only protected content is exactly what it
+--- already ignores, so it needs no change and the key stays in one binary.
+---
+--- Every write that replaces a stored blob goes through here, so a migration,
+--- edit, rename or backfill can no longer downgrade protected content to
+--- plaintext. Wire and export encodes are NOT routed here (Serialisation:95,
+--- Export.lua:31, Utils.lua:1838) -- those stay plain by policy.
+local function isProtected(tab)
+    local meta = type(tab) == "table"
+        and (tab.MetaData or (type(tab[2]) == "table" and tab[2].MetaData))
+    return type(meta) == "table" and meta.noExport and true or false
+end
+
+--- Key id is carried forward only when re-packing something already packed
+--- under a non-default key; today "1" is the only key issued.
+function GSE.EncodeLike(existing, tab)
+    if isProtected(tab) then
+        local keyId = "1"
+        if type(existing) == "string" and string.sub(existing, 1, 7) == "!GSE3!+" then
+            keyId = string.sub(existing, 8, 8)
+        end
+        return GSE.EncodePackedMessage(tab, keyId)
+    end
+    return GSE.EncodeMessage(tab)
+end
+
+--- True when a stored blob is protected content still sitting in the clear,
+--- so the load path can re-pack it. Own content returns false and is left
+--- alone. `decoded` is the already-decoded object, so this costs nothing.
+function GSE.NeedsRepack(blob, decoded)
+    if type(blob) ~= "string" then return false end
+    local packed = string.sub(blob, 1, 7) == "!GSE3!+"
+    local protected = isProtected(decoded)
+    -- Protected but in the clear -> pack it.
+    if not packed and protected then return true end
+    -- Packed but NOT protected -> the author's own content, which must stay
+    -- plain so the Companion can read it (wow.js:438 has no key). Rewrite it
+    -- plain. This also unwinds an over-broad pack from an earlier build.
+    if packed and not protected then return true end
+    return false
+end
+
 function GSE.DecodeMessage(data)
     if string.sub(data, 1, 7) == "!GSE3!+" then
         return pcall(GSE.DecodePackedMessage, data)

--- a/GSE/API/Serialisation.lua
+++ b/GSE/API/Serialisation.lua
@@ -10,58 +10,6 @@ function GSE.EncodeMessage(tab)
 end
 
 -- This decodes a string into a LUA Table.  This returns a bool (success) and an object that contains the results.
---- Encode for STORAGE (GSESequences / GSEVariables).
----
---- The envelope follows ONE fact: is this protected content (MetaData.noExport,
---- set by gse.tools on copies sent to someone who does not own them). It is NOT
---- inherited from whatever was on disk -- inheriting makes the envelope sticky,
---- so a blob packed by an over-broad build could never return to plain.
----
---- Protected content is packed; the author's OWN content stays plain, on
---- purpose. The GSE Companion desktop app decodes GSE.lua directly and is
---- deliberately blind to !GSE3!+ ("opaque to the Companion by design -- no
---- key", wow.js:438). Packing only protected content is exactly what it
---- already ignores, so it needs no change and the key stays in one binary.
----
---- Every write that replaces a stored blob goes through here, so a migration,
---- edit, rename or backfill can no longer downgrade protected content to
---- plaintext. Wire and export encodes are NOT routed here (Serialisation:95,
---- Export.lua:31, Utils.lua:1838) -- those stay plain by policy.
-local function isProtected(tab)
-    local meta = type(tab) == "table"
-        and (tab.MetaData or (type(tab[2]) == "table" and tab[2].MetaData))
-    return type(meta) == "table" and meta.noExport and true or false
-end
-
---- Key id is carried forward only when re-packing something already packed
---- under a non-default key; today "1" is the only key issued.
-function GSE.EncodeLike(existing, tab)
-    if isProtected(tab) then
-        local keyId = "1"
-        if type(existing) == "string" and string.sub(existing, 1, 7) == "!GSE3!+" then
-            keyId = string.sub(existing, 8, 8)
-        end
-        return GSE.EncodePackedMessage(tab, keyId)
-    end
-    return GSE.EncodeMessage(tab)
-end
-
---- True when a stored blob is protected content still sitting in the clear,
---- so the load path can re-pack it. Own content returns false and is left
---- alone. `decoded` is the already-decoded object, so this costs nothing.
-function GSE.NeedsRepack(blob, decoded)
-    if type(blob) ~= "string" then return false end
-    local packed = string.sub(blob, 1, 7) == "!GSE3!+"
-    local protected = isProtected(decoded)
-    -- Protected but in the clear -> pack it.
-    if not packed and protected then return true end
-    -- Packed but NOT protected -> the author's own content, which must stay
-    -- plain so the Companion can read it (wow.js:438 has no key). Rewrite it
-    -- plain. This also unwinds an over-broad pack from an earlier build.
-    if packed and not protected then return true end
-    return false
-end
-
 function GSE.DecodeMessage(data)
     if string.sub(data, 1, 7) == "!GSE3!+" then
         return pcall(GSE.DecodePackedMessage, data)

--- a/GSE/API/Storage.lua
+++ b/GSE/API/Storage.lua
@@ -94,6 +94,71 @@ function GSE.StampOriginKey(sequence, name)
     return true
 end
 
+--- GSERepackQueue -- what GSE asks the Companion to re-seal on its behalf.
+--
+-- The addon does not produce packed envelopes (see GSE.IsPackedBlob), so when
+-- protected content genuinely needs one written it says so here and the
+-- Companion services it: resolve the record on gse.tools, fetch the sealed
+-- blob the server produces, write it back. The key never has to exist on this
+-- side of the wire.
+--
+-- Entries carry IDENTITY ONLY -- never a decoded body. Putting the plaintext
+-- in the request would recreate the exact exposure #2054 is about, in a second
+-- place.
+--
+-- Keyed so a request is idempotent: logging in ten times with the same damaged
+-- library leaves one entry, not ten.
+local function repackKey(contentType, classid, name)
+    return tostring(contentType) .. ":" .. tostring(classid or "") .. ":" .. tostring(name)
+end
+
+function GSE.QueueRepack(contentType, classid, name, obj, reason)
+    if GSE.isEmpty(name) then return false end
+    if type(GSERepackQueue) ~= "table" then GSERepackQueue = {} end
+    local meta = (type(obj) == "table" and obj.MetaData) or {}
+    local key = repackKey(contentType, classid, name)
+    -- Keep the first sighting's timestamp; this is a standing request, and a
+    -- fresh stamp on every login would make it look perpetually new.
+    local existing = GSERepackQueue[key]
+    GSERepackQueue[key] = {
+        t = contentType,
+        classid = classid,
+        name = name,
+        -- Protected content is content gse.tools sent here, so it arrives with
+        -- a PlatformID already on it. That is the record the Companion asks the
+        -- server to re-seal, and the only identity this request needs.
+        platformId = meta.PlatformID,
+        reason = reason,
+        stamp = (existing and existing.stamp) or GSE.GetTimestamp(),
+    }
+    return true
+end
+
+function GSE.ClearRepackRequest(contentType, classid, name)
+    if type(GSERepackQueue) ~= "table" then return end
+    GSERepackQueue[repackKey(contentType, classid, name)] = nil
+end
+
+--- Called on every load, whatever else happens to the record.
+--
+-- Protected content sitting in the clear is the damage a shipped build already
+-- did (#2054) and it cannot be repaired here, so it is reported. Anything
+-- correctly sealed clears its request, which is what makes the queue
+-- self-draining: once the Companion writes the sealed blob back, the next login
+-- removes the entry rather than leaving it to be serviced forever.
+function GSE.AuditProtectedAtRest(contentType, classid, name, blob, obj)
+    if not GSE.IsProtectedContent(obj) then
+        GSE.ClearRepackRequest(contentType, classid, name)
+        return false
+    end
+    if GSE.IsPackedBlob(blob) then
+        GSE.ClearRepackRequest(contentType, classid, name)
+        return false
+    end
+    GSE.QueueRepack(contentType, classid, name, obj, "plaintext-at-rest")
+    return true
+end
+
 local function migrateSequenceVersions(sequence, sequenceName)
     if type(sequence) ~= "table" then return false end
     if sequence["Macros"] ~= nil and sequence.Versions == nil then
@@ -135,6 +200,12 @@ local function loadOneClass(classid)
             function()
                 local localsuccess, uncompressedVersion = GSE.DecodeMessage(j)
                 GSE.Library[classid][i] = uncompressedVersion[2]
+                -- A locally-edited copy lives in GSEDeltas; the stored blob is
+                -- only its base. Prefer the reconstruction or the edit is lost
+                -- the first time this class is loaded lazily.
+                local forked = GSE.ApplyStoredDeltaFork and GSE.ApplyStoredDeltaFork(GSE.Library[classid][i])
+                if forked then GSE.Library[classid][i] = forked end
+                GSE.AuditProtectedAtRest("sequence", classid, i, j, GSE.Library[classid][i])
                 local changed, reason = migrateSequenceVersions(GSE.Library[classid][i], i)
                 if reason == "macros-deprecated" then
                     -- Refuse to load. The on-disk record uses the old
@@ -144,7 +215,11 @@ local function loadOneClass(classid)
                         L["Sequence '%s' is incompatible with the current version of GSE. Upload it to https://gse.tools to update it to the current format, then re-import."],
                         i))
                 end
-                if changed then
+                -- Migration results are derived and recomputed on every load,
+                -- so declining to persist them costs nothing. Rewriting them
+                -- over protected content, on the other hand, is what stripped
+                -- the packed envelope in #2054.
+                if changed and not GSE.IsProtectedAtRest(GSESequences[classid][i], GSE.Library[classid][i]) then
                     GSESequences[classid][i] = GSE.EncodeMessage({i, GSE.Library[classid][i]})
                 end
             end
@@ -185,6 +260,11 @@ function GSE.EnsureSequenceLoaded(classid, sequenceName)
             local localsuccess, uncompressedVersion = GSE.DecodeMessage(GSESequences[classid][sequenceName])
             if localsuccess then
                 GSE.Library[classid][sequenceName] = uncompressedVersion[2]
+                local forked = GSE.ApplyStoredDeltaFork
+                    and GSE.ApplyStoredDeltaFork(GSE.Library[classid][sequenceName])
+                if forked then GSE.Library[classid][sequenceName] = forked end
+                GSE.AuditProtectedAtRest("sequence", classid, sequenceName,
+                    GSESequences[classid][sequenceName], GSE.Library[classid][sequenceName])
                 local changed, reason = migrateSequenceVersions(GSE.Library[classid][sequenceName], sequenceName)
                 if reason == "macros-deprecated" then
                     GSE.Library[classid][sequenceName] = nil
@@ -192,7 +272,8 @@ function GSE.EnsureSequenceLoaded(classid, sequenceName)
                         L["Sequence '%s' is incompatible with the current version of GSE. Upload it to https://gse.tools to update it to the current format, then re-import."],
                         sequenceName))
                 end
-                if changed then
+                if changed and not GSE.IsProtectedAtRest(GSESequences[classid][sequenceName],
+                    GSE.Library[classid][sequenceName]) then
                     GSESequences[classid][sequenceName] = GSE.EncodeMessage({sequenceName, GSE.Library[classid][sequenceName]})
                 end
             end
@@ -559,9 +640,29 @@ function GSE.ReplaceSequence(classid, sequenceName, sequence)
     if GSE.SanitizeSequenceEditorMarkup then
         GSE.SanitizeSequenceEditorMarkup(sequence)
     end
+    -- Stamp on save, not only on the next load: a sequence created or renamed
+    -- within one session must already carry the key it was born with, rather
+    -- than acquiring it whenever it is next read back. Idempotent -- an
+    -- existing stamp is left alone.
+    GSE.StampOriginKey(sequence, sequenceName)
     GSE.ComputeSequenceDependencies(sequence)
     GSE.SnapshotDependentMacros(sequence)
     if GSE.UpdateDeltaFork and GSE.UpdateDeltaFork(sequence) then
+        GSE.Library[classid][sequenceName] = GSE.CloneSequence(sequence)
+        GSE:SendMessage(Statics.Messages.SEQUENCE_UPDATED, sequenceName)
+        return
+    end
+    -- Protected content is never rewritten in the clear, so an edit to it is
+    -- stored as a delta over the sealed blob instead: the packed base moves
+    -- into the fork verbatim and only the divergence is written beside it.
+    -- This branch is for protected content ONLY -- an ordinary sequence falls
+    -- through to the plain replace below, exactly as before.
+    if GSE.IsProtectedAtRest(GSESequences[classid][sequenceName], sequence) then
+        if not GSE.SeedDeltaFork(GSESequences[classid][sequenceName], sequence, "sequence") then
+            -- Nothing to key a fork by, so the edit cannot be persisted here.
+            -- Say so rather than writing it out in the clear.
+            GSE.QueueRepack("sequence", classid, sequenceName, sequence, "edit-needs-repack")
+        end
         GSE.Library[classid][sequenceName] = GSE.CloneSequence(sequence)
         GSE:SendMessage(Statics.Messages.SEQUENCE_UPDATED, sequenceName)
         return
@@ -639,8 +740,23 @@ function GSE.RenameSequence(classid, oldName, newName, sequence)
     GSE.ComputeSequenceDependencies(sequence)
     GSE.SnapshotDependentMacros(sequence)
 
-    -- Write under the new key.
-    GSESequences[classid][newName] = GSE.EncodeMessage({newName, sequence})
+    -- Write under the new key. A rename is a change of TABLE KEY, so protected
+    -- content moves as the string it already is -- the sealed blob is carried
+    -- across untouched and nothing needs encoding. The name inside the body is
+    -- MetaData.Name, which the caller has already updated.
+    if GSE.IsProtectedAtRest(GSESequences[classid][oldName], sequence) then
+        -- Only a blob that actually exists can be carried. A protected body
+        -- with nothing stored under the old key has nothing to move, and
+        -- assigning the nil across would drop the sequence from storage
+        -- altogether, so ask for a repack instead.
+        if GSESequences[classid][oldName] ~= nil then
+            GSESequences[classid][newName] = GSESequences[classid][oldName]
+        else
+            GSE.QueueRepack("sequence", classid, newName, sequence, "rename-needs-repack")
+        end
+    else
+        GSESequences[classid][newName] = GSE.EncodeMessage({newName, sequence})
+    end
     GSE.Library[classid][newName] = sequence
 
     -- Remove the old key so the old name is no longer in use.
@@ -822,6 +938,10 @@ local function loadOneVariable(k, v)
         function()
             local localsuccess, uncompressedVersion = GSE.DecodeMessage(v)
             if not localsuccess then return end
+            -- This path never writes back -- which is why variables kept their
+            -- envelope where sequences lost it -- so there is nothing to gate,
+            -- only damage from an earlier build to report.
+            GSE.AuditProtectedAtRest("variable", nil, k, v, uncompressedVersion)
             GSE.V[k] = gseLoadstring("return " .. uncompressedVersion.funct)()
             if type(GSE.V[k]()) == "boolean" then
                 GSE.BooleanVariables["GSE.V['" .. k .. "']()"] = "GSE.V['" .. k .. "']()"
@@ -2797,9 +2917,21 @@ function GSE.UpdateVariable(variable, name, status)
         GSE.CompanionCancelPendingDelete("variable", name)
     end
     GSE.ComputeVariableDependencies(variable)
-    local compressedvariable = GSE.EncodeMessage(variable)
-    if not (GSE.UpdateDeltaFork and GSE.UpdateDeltaFork(variable)) then
-        GSEVariables[name] = compressedvariable
+    local storedVariable = GSEVariables and GSEVariables[name]
+    if GSE.IsProtectedAtRest(storedVariable, variable) then
+        -- Same rule as a sequence: the sealed blob stays, the edit becomes a
+        -- delta over it, and if there is nothing to key a fork by we ask for a
+        -- repack rather than writing the variable out in the clear. A nil
+        -- stored value reaches SeedDeltaFork as nil and is refused there,
+        -- which lands on the same fallback.
+        if not GSE.SeedDeltaFork(storedVariable, variable, "variable") then
+            GSE.QueueRepack("variable", nil, name, variable, "edit-needs-repack")
+        end
+    else
+        local compressedvariable = GSE.EncodeMessage(variable)
+        if not (GSE.UpdateDeltaFork and GSE.UpdateDeltaFork(variable)) then
+            GSEVariables[name] = compressedvariable
+        end
     end
     local actualfunct, error = gseLoadstring("return " .. variable.funct)
     if error then
@@ -2844,7 +2976,13 @@ function GSE.BackfillLastUpdated()
         for classid, classLib in pairs(GSE.Library) do
             if type(classLib) == "table" then
                 for name, seq in pairs(classLib) do
-                    if type(seq) == "table" and not seq.LastUpdated then
+                    -- Skip protected content outright. There is no way to
+                    -- persist the stamp without rewriting the sealed blob, and
+                    -- an unwritten LastUpdated would be re-minted to a new
+                    -- `now` on every load anyway -- drift, not a backfill.
+                    if type(seq) == "table" and not seq.LastUpdated
+                        and not (GSESequences and GSESequences[classid]
+                            and GSE.IsProtectedAtRest(GSESequences[classid][name], seq)) then
                         seq.LastUpdated = now
                         if GSESequences and GSESequences[classid] then
                             GSESequences[classid][name] = GSE.EncodeMessage({name, seq})

--- a/GSE/API/Storage.lua
+++ b/GSE/API/Storage.lua
@@ -136,6 +136,13 @@ local function loadOneClass(classid)
                 local localsuccess, uncompressedVersion = GSE.DecodeMessage(j)
                 GSE.Library[classid][i] = uncompressedVersion[2]
                 local changed, reason = migrateSequenceVersions(GSE.Library[classid][i], i)
+                -- Self-heal: protected content stored in the clear (by a build
+                -- without this fix) is rewritten packed on load. Own content
+                -- is left plain -- see GSE.EncodeLike.
+                if not changed and reason == nil
+                    and GSE.NeedsRepack(GSESequences[classid][i], GSE.Library[classid][i]) then
+                    changed = true
+                end
                 if reason == "macros-deprecated" then
                     -- Refuse to load. The on-disk record uses the old
                     -- 'Macros' field; the addon no longer auto-renames.
@@ -145,7 +152,7 @@ local function loadOneClass(classid)
                         i))
                 end
                 if changed then
-                    GSESequences[classid][i] = GSE.EncodeMessage({i, GSE.Library[classid][i]})
+                    GSESequences[classid][i] = GSE.EncodeLike(GSESequences[classid][i], {i, GSE.Library[classid][i]})
                 end
             end
         )
@@ -186,6 +193,12 @@ function GSE.EnsureSequenceLoaded(classid, sequenceName)
             if localsuccess then
                 GSE.Library[classid][sequenceName] = uncompressedVersion[2]
                 local changed, reason = migrateSequenceVersions(GSE.Library[classid][sequenceName], sequenceName)
+                -- Self-heal: protected content stored in the clear is rewritten
+                -- packed on load; own content is left plain.
+                if not changed and reason == nil
+                    and GSE.NeedsRepack(GSESequences[classid][sequenceName], GSE.Library[classid][sequenceName]) then
+                    changed = true
+                end
                 if reason == "macros-deprecated" then
                     GSE.Library[classid][sequenceName] = nil
                     error(string.format(
@@ -193,7 +206,7 @@ function GSE.EnsureSequenceLoaded(classid, sequenceName)
                         sequenceName))
                 end
                 if changed then
-                    GSESequences[classid][sequenceName] = GSE.EncodeMessage({sequenceName, GSE.Library[classid][sequenceName]})
+                    GSESequences[classid][sequenceName] = GSE.EncodeLike(GSESequences[classid][sequenceName], {sequenceName, GSE.Library[classid][sequenceName]})
                 end
             end
         end
@@ -559,6 +572,10 @@ function GSE.ReplaceSequence(classid, sequenceName, sequence)
     if GSE.SanitizeSequenceEditorMarkup then
         GSE.SanitizeSequenceEditorMarkup(sequence)
     end
+    -- Stamp on save, not only on the next load: a sequence created, exported
+    -- or renamed within one session must already carry the key it was born
+    -- with. Idempotent -- an existing stamp is left alone.
+    GSE.StampOriginKey(sequence, sequenceName)
     GSE.ComputeSequenceDependencies(sequence)
     GSE.SnapshotDependentMacros(sequence)
     if GSE.UpdateDeltaFork and GSE.UpdateDeltaFork(sequence) then
@@ -568,7 +585,7 @@ function GSE.ReplaceSequence(classid, sequenceName, sequence)
     end
     -- Checksum is stamped on export only, not on save, so the stored checksum
     -- always reflects the last-exported state rather than the current edit state.
-    GSESequences[classid][sequenceName] = GSE.EncodeMessage({sequenceName, sequence})
+    GSESequences[classid][sequenceName] = GSE.EncodeLike(GSESequences[classid][sequenceName], {sequenceName, sequence})
     GSE.Library[classid][sequenceName] = GSE.CloneSequence(sequence)
     GSE:SendMessage(Statics.Messages.SEQUENCE_UPDATED, sequenceName)
 end
@@ -640,7 +657,7 @@ function GSE.RenameSequence(classid, oldName, newName, sequence)
     GSE.SnapshotDependentMacros(sequence)
 
     -- Write under the new key.
-    GSESequences[classid][newName] = GSE.EncodeMessage({newName, sequence})
+    GSESequences[classid][newName] = GSE.EncodeLike(GSESequences[classid][oldName], {newName, sequence})
     GSE.Library[classid][newName] = sequence
 
     -- Remove the old key so the old name is no longer in use.
@@ -823,6 +840,11 @@ local function loadOneVariable(k, v)
             local localsuccess, uncompressedVersion = GSE.DecodeMessage(v)
             if not localsuccess then return end
             GSE.V[k] = gseLoadstring("return " .. uncompressedVersion.funct)()
+            -- Self-heal: a protected variable stored in the clear is rewritten
+            -- packed on load; the author's own variables stay plain.
+            if GSE.NeedsRepack(v, uncompressedVersion) then
+                GSEVariables[k] = GSE.EncodeLike(v, uncompressedVersion)
+            end
             if type(GSE.V[k]()) == "boolean" then
                 GSE.BooleanVariables["GSE.V['" .. k .. "']()"] = "GSE.V['" .. k .. "']()"
             end
@@ -2797,7 +2819,7 @@ function GSE.UpdateVariable(variable, name, status)
         GSE.CompanionCancelPendingDelete("variable", name)
     end
     GSE.ComputeVariableDependencies(variable)
-    local compressedvariable = GSE.EncodeMessage(variable)
+    local compressedvariable = GSE.EncodeLike(GSEVariables and GSEVariables[name], variable)
     if not (GSE.UpdateDeltaFork and GSE.UpdateDeltaFork(variable)) then
         GSEVariables[name] = compressedvariable
     end
@@ -2847,7 +2869,7 @@ function GSE.BackfillLastUpdated()
                     if type(seq) == "table" and not seq.LastUpdated then
                         seq.LastUpdated = now
                         if GSESequences and GSESequences[classid] then
-                            GSESequences[classid][name] = GSE.EncodeMessage({name, seq})
+                            GSESequences[classid][name] = GSE.EncodeLike(GSESequences[classid][name], {name, seq})
                         end
                         touched = touched + 1
                     end

--- a/GSE/API/Storage.lua
+++ b/GSE/API/Storage.lua
@@ -136,13 +136,6 @@ local function loadOneClass(classid)
                 local localsuccess, uncompressedVersion = GSE.DecodeMessage(j)
                 GSE.Library[classid][i] = uncompressedVersion[2]
                 local changed, reason = migrateSequenceVersions(GSE.Library[classid][i], i)
-                -- Self-heal: protected content stored in the clear (by a build
-                -- without this fix) is rewritten packed on load. Own content
-                -- is left plain -- see GSE.EncodeLike.
-                if not changed and reason == nil
-                    and GSE.NeedsRepack(GSESequences[classid][i], GSE.Library[classid][i]) then
-                    changed = true
-                end
                 if reason == "macros-deprecated" then
                     -- Refuse to load. The on-disk record uses the old
                     -- 'Macros' field; the addon no longer auto-renames.
@@ -152,7 +145,7 @@ local function loadOneClass(classid)
                         i))
                 end
                 if changed then
-                    GSESequences[classid][i] = GSE.EncodeLike(GSESequences[classid][i], {i, GSE.Library[classid][i]})
+                    GSESequences[classid][i] = GSE.EncodeMessage({i, GSE.Library[classid][i]})
                 end
             end
         )
@@ -193,12 +186,6 @@ function GSE.EnsureSequenceLoaded(classid, sequenceName)
             if localsuccess then
                 GSE.Library[classid][sequenceName] = uncompressedVersion[2]
                 local changed, reason = migrateSequenceVersions(GSE.Library[classid][sequenceName], sequenceName)
-                -- Self-heal: protected content stored in the clear is rewritten
-                -- packed on load; own content is left plain.
-                if not changed and reason == nil
-                    and GSE.NeedsRepack(GSESequences[classid][sequenceName], GSE.Library[classid][sequenceName]) then
-                    changed = true
-                end
                 if reason == "macros-deprecated" then
                     GSE.Library[classid][sequenceName] = nil
                     error(string.format(
@@ -206,7 +193,7 @@ function GSE.EnsureSequenceLoaded(classid, sequenceName)
                         sequenceName))
                 end
                 if changed then
-                    GSESequences[classid][sequenceName] = GSE.EncodeLike(GSESequences[classid][sequenceName], {sequenceName, GSE.Library[classid][sequenceName]})
+                    GSESequences[classid][sequenceName] = GSE.EncodeMessage({sequenceName, GSE.Library[classid][sequenceName]})
                 end
             end
         end
@@ -572,10 +559,6 @@ function GSE.ReplaceSequence(classid, sequenceName, sequence)
     if GSE.SanitizeSequenceEditorMarkup then
         GSE.SanitizeSequenceEditorMarkup(sequence)
     end
-    -- Stamp on save, not only on the next load: a sequence created, exported
-    -- or renamed within one session must already carry the key it was born
-    -- with. Idempotent -- an existing stamp is left alone.
-    GSE.StampOriginKey(sequence, sequenceName)
     GSE.ComputeSequenceDependencies(sequence)
     GSE.SnapshotDependentMacros(sequence)
     if GSE.UpdateDeltaFork and GSE.UpdateDeltaFork(sequence) then
@@ -585,7 +568,7 @@ function GSE.ReplaceSequence(classid, sequenceName, sequence)
     end
     -- Checksum is stamped on export only, not on save, so the stored checksum
     -- always reflects the last-exported state rather than the current edit state.
-    GSESequences[classid][sequenceName] = GSE.EncodeLike(GSESequences[classid][sequenceName], {sequenceName, sequence})
+    GSESequences[classid][sequenceName] = GSE.EncodeMessage({sequenceName, sequence})
     GSE.Library[classid][sequenceName] = GSE.CloneSequence(sequence)
     GSE:SendMessage(Statics.Messages.SEQUENCE_UPDATED, sequenceName)
 end
@@ -657,7 +640,7 @@ function GSE.RenameSequence(classid, oldName, newName, sequence)
     GSE.SnapshotDependentMacros(sequence)
 
     -- Write under the new key.
-    GSESequences[classid][newName] = GSE.EncodeLike(GSESequences[classid][oldName], {newName, sequence})
+    GSESequences[classid][newName] = GSE.EncodeMessage({newName, sequence})
     GSE.Library[classid][newName] = sequence
 
     -- Remove the old key so the old name is no longer in use.
@@ -840,11 +823,6 @@ local function loadOneVariable(k, v)
             local localsuccess, uncompressedVersion = GSE.DecodeMessage(v)
             if not localsuccess then return end
             GSE.V[k] = gseLoadstring("return " .. uncompressedVersion.funct)()
-            -- Self-heal: a protected variable stored in the clear is rewritten
-            -- packed on load; the author's own variables stay plain.
-            if GSE.NeedsRepack(v, uncompressedVersion) then
-                GSEVariables[k] = GSE.EncodeLike(v, uncompressedVersion)
-            end
             if type(GSE.V[k]()) == "boolean" then
                 GSE.BooleanVariables["GSE.V['" .. k .. "']()"] = "GSE.V['" .. k .. "']()"
             end
@@ -2819,7 +2797,7 @@ function GSE.UpdateVariable(variable, name, status)
         GSE.CompanionCancelPendingDelete("variable", name)
     end
     GSE.ComputeVariableDependencies(variable)
-    local compressedvariable = GSE.EncodeLike(GSEVariables and GSEVariables[name], variable)
+    local compressedvariable = GSE.EncodeMessage(variable)
     if not (GSE.UpdateDeltaFork and GSE.UpdateDeltaFork(variable)) then
         GSEVariables[name] = compressedvariable
     end
@@ -2869,7 +2847,7 @@ function GSE.BackfillLastUpdated()
                     if type(seq) == "table" and not seq.LastUpdated then
                         seq.LastUpdated = now
                         if GSESequences and GSESequences[classid] then
-                            GSESequences[classid][name] = GSE.EncodeLike(GSESequences[classid][name], {name, seq})
+                            GSESequences[classid][name] = GSE.EncodeMessage({name, seq})
                         end
                         touched = touched + 1
                     end

--- a/GSE/GSE.toc
+++ b/GSE/GSE.toc
@@ -4,7 +4,7 @@
 ## Notes: Create Sequence buttons and Macros using powerful API functions.
 ## Author: TimothyLuke
 ## Version: @project-version@
-## SavedVariables: GSEOptions GSESequences GSESpellCache GSEVariables GSEMacros GSEPlatformIDs GSEVariablePlatformIDs GSEMacroPlatformIDs GSESupportReports GSEDeltas
+## SavedVariables: GSEOptions GSESequences GSESpellCache GSEVariables GSEMacros GSEPlatformIDs GSEVariablePlatformIDs GSEMacroPlatformIDs GSESupportReports GSEDeltas GSERepackQueue
 ## SavedVariablesPerCharacter: GSE_C GSELegacyLibraryBackup
 ## LoadSavedVariablesFirst: 1
 

--- a/GSE_GUI/Editor.lua
+++ b/GSE_GUI/Editor.lua
@@ -1832,7 +1832,7 @@ function GSE.HydrateClassActionIcons(classid)
         if sequenceShowTooltipChanges > 0 and GSESequences and GSESequences[classid] and
             GSESequences[classid][sequenceName] then
             if type(sequence.MetaData) == "table" then sequence.MetaData.Checksum = nil end
-            GSESequences[classid][sequenceName] = GSE.EncodeMessage({sequenceName, sequence})
+            GSESequences[classid][sequenceName] = GSE.EncodeLike(GSESequences[classid][sequenceName], {sequenceName, sequence})
             sequenceChangedIcons = sequenceChangedIcons - sequenceShowTooltipChanges
         end
         if sequenceChangedIcons > 0 then
@@ -1893,7 +1893,7 @@ function GSE.HydrateLoadedSequenceActionIcons(scanStats, saveChanges)
                 local pendingIconSaves = actionIconDirtySequences[sequence] or 0
                 if saveChanges then
                     if (changed or pendingIconSaves > 0) and GSESequences and GSESequences[classid] then
-                        GSESequences[classid][sequenceName] = GSE.EncodeMessage({sequenceName, sequence})
+                        GSESequences[classid][sequenceName] = GSE.EncodeLike(GSESequences[classid][sequenceName], {sequenceName, sequence})
                         savedSequences = savedSequences + 1
                         savedIcons = savedIcons + sequenceChangedIcons + pendingIconSaves
                         actionIconDirtySequences[sequence] = nil
@@ -1953,7 +1953,7 @@ function GSE.ResetLoadedSequenceActionIcons(scanStats, saveChanges)
                 end
 
                 if saveChanges and changed and GSESequences and GSESequences[classid] then
-                    GSESequences[classid][sequenceName] = GSE.EncodeMessage({sequenceName, sequence})
+                    GSESequences[classid][sequenceName] = GSE.EncodeLike(GSESequences[classid][sequenceName], {sequenceName, sequence})
                     savedSequences = savedSequences + 1
                     savedIcons = savedIcons + sequenceRefreshedIcons + sequenceClearedUserSelections
                     actionIconDirtySequences[sequence] = nil
@@ -8037,7 +8037,7 @@ function GSE.GUICreateNewSequence(editor, name, recordedstring)
         sequence.Versions[1]["Actions"] = recordedMacro
     end
     if GSE.isEmpty(sequence.WeakAuras) then sequence.WeakAuras = {} end
-    GSESequences[classid][name] = GSE.EncodeMessage({name, sequence})
+    GSESequences[classid][name] = GSE.EncodeLike(GSESequences[classid][name], {name, sequence})
     GSE.Library[classid][name]  = sequence
     editor:SetStatusText("GSE: " .. GSE.VersionString)
     editor.SequenceName     = name

--- a/GSE_GUI/Editor.lua
+++ b/GSE_GUI/Editor.lua
@@ -1832,7 +1832,7 @@ function GSE.HydrateClassActionIcons(classid)
         if sequenceShowTooltipChanges > 0 and GSESequences and GSESequences[classid] and
             GSESequences[classid][sequenceName] then
             if type(sequence.MetaData) == "table" then sequence.MetaData.Checksum = nil end
-            GSESequences[classid][sequenceName] = GSE.EncodeLike(GSESequences[classid][sequenceName], {sequenceName, sequence})
+            GSESequences[classid][sequenceName] = GSE.EncodeMessage({sequenceName, sequence})
             sequenceChangedIcons = sequenceChangedIcons - sequenceShowTooltipChanges
         end
         if sequenceChangedIcons > 0 then
@@ -1893,7 +1893,7 @@ function GSE.HydrateLoadedSequenceActionIcons(scanStats, saveChanges)
                 local pendingIconSaves = actionIconDirtySequences[sequence] or 0
                 if saveChanges then
                     if (changed or pendingIconSaves > 0) and GSESequences and GSESequences[classid] then
-                        GSESequences[classid][sequenceName] = GSE.EncodeLike(GSESequences[classid][sequenceName], {sequenceName, sequence})
+                        GSESequences[classid][sequenceName] = GSE.EncodeMessage({sequenceName, sequence})
                         savedSequences = savedSequences + 1
                         savedIcons = savedIcons + sequenceChangedIcons + pendingIconSaves
                         actionIconDirtySequences[sequence] = nil
@@ -1953,7 +1953,7 @@ function GSE.ResetLoadedSequenceActionIcons(scanStats, saveChanges)
                 end
 
                 if saveChanges and changed and GSESequences and GSESequences[classid] then
-                    GSESequences[classid][sequenceName] = GSE.EncodeLike(GSESequences[classid][sequenceName], {sequenceName, sequence})
+                    GSESequences[classid][sequenceName] = GSE.EncodeMessage({sequenceName, sequence})
                     savedSequences = savedSequences + 1
                     savedIcons = savedIcons + sequenceRefreshedIcons + sequenceClearedUserSelections
                     actionIconDirtySequences[sequence] = nil
@@ -8037,7 +8037,7 @@ function GSE.GUICreateNewSequence(editor, name, recordedstring)
         sequence.Versions[1]["Actions"] = recordedMacro
     end
     if GSE.isEmpty(sequence.WeakAuras) then sequence.WeakAuras = {} end
-    GSESequences[classid][name] = GSE.EncodeLike(GSESequences[classid][name], {name, sequence})
+    GSESequences[classid][name] = GSE.EncodeMessage({name, sequence})
     GSE.Library[classid][name]  = sequence
     editor:SetStatusText("GSE: " .. GSE.VersionString)
     editor.SequenceName     = name

--- a/GSE_GUI/Editor.lua
+++ b/GSE_GUI/Editor.lua
@@ -1832,7 +1832,11 @@ function GSE.HydrateClassActionIcons(classid)
         if sequenceShowTooltipChanges > 0 and GSESequences and GSESequences[classid] and
             GSESequences[classid][sequenceName] then
             if type(sequence.MetaData) == "table" then sequence.MetaData.Checksum = nil end
-            GSESequences[classid][sequenceName] = GSE.EncodeMessage({sequenceName, sequence})
+            -- Resolved icons are a cache, re-derived on every load, so leaving
+            -- protected content sealed costs one re-hydrate and nothing else.
+            if not GSE.IsProtectedAtRest(GSESequences[classid][sequenceName], sequence) then
+                GSESequences[classid][sequenceName] = GSE.EncodeMessage({sequenceName, sequence})
+            end
             sequenceChangedIcons = sequenceChangedIcons - sequenceShowTooltipChanges
         end
         if sequenceChangedIcons > 0 then
@@ -1892,7 +1896,8 @@ function GSE.HydrateLoadedSequenceActionIcons(scanStats, saveChanges)
 
                 local pendingIconSaves = actionIconDirtySequences[sequence] or 0
                 if saveChanges then
-                    if (changed or pendingIconSaves > 0) and GSESequences and GSESequences[classid] then
+                    if (changed or pendingIconSaves > 0) and GSESequences and GSESequences[classid]
+                        and not GSE.IsProtectedAtRest(GSESequences[classid][sequenceName], sequence) then
                         GSESequences[classid][sequenceName] = GSE.EncodeMessage({sequenceName, sequence})
                         savedSequences = savedSequences + 1
                         savedIcons = savedIcons + sequenceChangedIcons + pendingIconSaves
@@ -1952,7 +1957,8 @@ function GSE.ResetLoadedSequenceActionIcons(scanStats, saveChanges)
                     changedSequences = changedSequences + 1
                 end
 
-                if saveChanges and changed and GSESequences and GSESequences[classid] then
+                if saveChanges and changed and GSESequences and GSESequences[classid]
+                    and not GSE.IsProtectedAtRest(GSESequences[classid][sequenceName], sequence) then
                     GSESequences[classid][sequenceName] = GSE.EncodeMessage({sequenceName, sequence})
                     savedSequences = savedSequences + 1
                     savedIcons = savedIcons + sequenceRefreshedIcons + sequenceClearedUserSelections

--- a/GSE_QoL/QoL.lua
+++ b/GSE_QoL/QoL.lua
@@ -155,7 +155,7 @@ local function onSequenceSaved(_, sequenceName)
         local seq = GSE.Library[classid] and GSE.Library[classid][sequenceName]
         if seq and seq.MetaData then
             seq.MetaData.Checksum = GSE.ComputeSequenceChecksum(seq)
-            GSESequences[classid][sequenceName] = GSE.EncodeMessage({sequenceName, seq})
+            GSESequences[classid][sequenceName] = GSE.EncodeLike(GSESequences[classid][sequenceName], {sequenceName, seq})
             break
         end
     end

--- a/GSE_QoL/QoL.lua
+++ b/GSE_QoL/QoL.lua
@@ -155,7 +155,11 @@ local function onSequenceSaved(_, sequenceName)
         local seq = GSE.Library[classid] and GSE.Library[classid][sequenceName]
         if seq and seq.MetaData then
             seq.MetaData.Checksum = GSE.ComputeSequenceChecksum(seq)
-            GSESequences[classid][sequenceName] = GSE.EncodeMessage({sequenceName, seq})
+            -- The checksum is computed from the body, so it is recovered on the
+            -- next load; protected content keeps its sealed blob instead.
+            if not GSE.IsProtectedAtRest(GSESequences[classid][sequenceName], seq) then
+                GSESequences[classid][sequenceName] = GSE.EncodeMessage({sequenceName, seq})
+            end
             break
         end
     end

--- a/GSE_QoL/QoL.lua
+++ b/GSE_QoL/QoL.lua
@@ -155,7 +155,7 @@ local function onSequenceSaved(_, sequenceName)
         local seq = GSE.Library[classid] and GSE.Library[classid][sequenceName]
         if seq and seq.MetaData then
             seq.MetaData.Checksum = GSE.ComputeSequenceChecksum(seq)
-            GSESequences[classid][sequenceName] = GSE.EncodeLike(GSESequences[classid][sequenceName], {sequenceName, seq})
+            GSESequences[classid][sequenceName] = GSE.EncodeMessage({sequenceName, seq})
             break
         end
     end

--- a/GSE_Utils/Utils.lua
+++ b/GSE_Utils/Utils.lua
@@ -139,6 +139,25 @@ function GSE.OOCAddSequenceToCollection(sequenceName, sequence, classid)
     GSE:SendMessage(Statics.Messages.SEQUENCE_UPDATED, sequenceName)
 end
 
+--- Store the result of a merge action, unless that would put protected content
+-- on disk in the clear.
+--
+-- This path only ever holds a DECODED body -- the import dialog hands over the
+-- sequence, not the envelope it arrived in -- so there is no sealed blob here
+-- to carry across the way a rename or an edit can. When the content is
+-- protected the write is declined and a repack request is left instead: the
+-- session keeps working from the Library, and the Companion fetches the sealed
+-- blob from gse.tools to put the record straight.
+local function storeMergedSequence(classid, sequenceName, reason)
+    local seq = GSE.Library[classid][sequenceName]
+    if GSE.IsProtectedAtRest(GSESequences[classid][sequenceName], seq) then
+        GSE.QueueRepack("sequence", classid, sequenceName, seq, reason)
+        return false
+    end
+    GSESequences[classid][sequenceName] = GSE.EncodeMessage({sequenceName, seq})
+    return true
+end
+
 function GSE.OOCPerformMergeAction(action, classid, sequenceName, newSequence)
     -- Refuse to merge/replace with a Macros-only payload. Auto-rename
     -- has been retired; the user must re-export through gse.tools so
@@ -190,7 +209,7 @@ function GSE.OOCPerformMergeAction(action, classid, sequenceName, newSequence)
         --@end-debug@
         GSE.Print(string.format(L["Extra Sequence Versions of %s have been added."], sequenceName), GNOME)
         GSE.ComputeSequenceDependencies(GSE.Library[classid][sequenceName])
-        GSESequences[classid][sequenceName] = GSE.EncodeMessage({sequenceName, GSE.Library[classid][sequenceName]})
+        storeMergedSequence(classid, sequenceName, "merge-needs-repack")
     elseif action == "REPLACE" then
         GSE.Library[classid][sequenceName] = {}
         GSE.Library[classid][sequenceName] = newSequence
@@ -201,13 +220,13 @@ function GSE.OOCPerformMergeAction(action, classid, sequenceName, newSequence)
         GSE.PrintDebugMessage(" New Entry: " .. GSE.Dump(GSE.Library[classid][sequenceName]), "Storage")
         --@end-debug@
         GSE.ComputeSequenceDependencies(GSE.Library[classid][sequenceName])
-        GSESequences[classid][sequenceName] = GSE.EncodeMessage({sequenceName, GSE.Library[classid][sequenceName]})
+        storeMergedSequence(classid, sequenceName, "replace-needs-repack")
         GSE.Print(sequenceName .. L[" was updated to new version."], "Storage")
     elseif action == "RENAME" then
         GSE.Library[classid][sequenceName] = {}
         GSE.Library[classid][sequenceName] = newSequence
         GSE.ComputeSequenceDependencies(GSE.Library[classid][sequenceName])
-        GSESequences[classid][sequenceName] = GSE.EncodeMessage({sequenceName, GSE.Library[classid][sequenceName]})
+        storeMergedSequence(classid, sequenceName, "rename-needs-repack")
         GSE.Print(sequenceName .. L[" was imported as a new sequence."], "Storage")
         --@debug@
         GSE.PrintDebugMessage(

--- a/GSE_Utils/Utils.lua
+++ b/GSE_Utils/Utils.lua
@@ -169,6 +169,9 @@ function GSE.OOCPerformMergeAction(action, classid, sequenceName, newSequence)
         )
         sequenceName = tempseqName
     end
+    -- Every new and imported sequence lands here. Stamp it under the name it
+    -- is stored as, before the next load would; an existing stamp is kept.
+    GSE.StampOriginKey(newSequence, sequenceName)
     if action == "MERGE" then
         -- Both sides need a Versions table. Migration above set them up;
         -- belt-and-braces: if either is still nil, init/empty out so the
@@ -190,7 +193,7 @@ function GSE.OOCPerformMergeAction(action, classid, sequenceName, newSequence)
         --@end-debug@
         GSE.Print(string.format(L["Extra Sequence Versions of %s have been added."], sequenceName), GNOME)
         GSE.ComputeSequenceDependencies(GSE.Library[classid][sequenceName])
-        GSESequences[classid][sequenceName] = GSE.EncodeMessage({sequenceName, GSE.Library[classid][sequenceName]})
+        GSESequences[classid][sequenceName] = GSE.EncodeLike(GSESequences[classid][sequenceName], {sequenceName, GSE.Library[classid][sequenceName]})
     elseif action == "REPLACE" then
         GSE.Library[classid][sequenceName] = {}
         GSE.Library[classid][sequenceName] = newSequence
@@ -201,13 +204,13 @@ function GSE.OOCPerformMergeAction(action, classid, sequenceName, newSequence)
         GSE.PrintDebugMessage(" New Entry: " .. GSE.Dump(GSE.Library[classid][sequenceName]), "Storage")
         --@end-debug@
         GSE.ComputeSequenceDependencies(GSE.Library[classid][sequenceName])
-        GSESequences[classid][sequenceName] = GSE.EncodeMessage({sequenceName, GSE.Library[classid][sequenceName]})
+        GSESequences[classid][sequenceName] = GSE.EncodeLike(GSESequences[classid][sequenceName], {sequenceName, GSE.Library[classid][sequenceName]})
         GSE.Print(sequenceName .. L[" was updated to new version."], "Storage")
     elseif action == "RENAME" then
         GSE.Library[classid][sequenceName] = {}
         GSE.Library[classid][sequenceName] = newSequence
         GSE.ComputeSequenceDependencies(GSE.Library[classid][sequenceName])
-        GSESequences[classid][sequenceName] = GSE.EncodeMessage({sequenceName, GSE.Library[classid][sequenceName]})
+        GSESequences[classid][sequenceName] = GSE.EncodeLike(GSESequences[classid][sequenceName], {sequenceName, GSE.Library[classid][sequenceName]})
         GSE.Print(sequenceName .. L[" was imported as a new sequence."], "Storage")
         --@debug@
         GSE.PrintDebugMessage(

--- a/GSE_Utils/Utils.lua
+++ b/GSE_Utils/Utils.lua
@@ -169,9 +169,6 @@ function GSE.OOCPerformMergeAction(action, classid, sequenceName, newSequence)
         )
         sequenceName = tempseqName
     end
-    -- Every new and imported sequence lands here. Stamp it under the name it
-    -- is stored as, before the next load would; an existing stamp is kept.
-    GSE.StampOriginKey(newSequence, sequenceName)
     if action == "MERGE" then
         -- Both sides need a Versions table. Migration above set them up;
         -- belt-and-braces: if either is still nil, init/empty out so the
@@ -193,7 +190,7 @@ function GSE.OOCPerformMergeAction(action, classid, sequenceName, newSequence)
         --@end-debug@
         GSE.Print(string.format(L["Extra Sequence Versions of %s have been added."], sequenceName), GNOME)
         GSE.ComputeSequenceDependencies(GSE.Library[classid][sequenceName])
-        GSESequences[classid][sequenceName] = GSE.EncodeLike(GSESequences[classid][sequenceName], {sequenceName, GSE.Library[classid][sequenceName]})
+        GSESequences[classid][sequenceName] = GSE.EncodeMessage({sequenceName, GSE.Library[classid][sequenceName]})
     elseif action == "REPLACE" then
         GSE.Library[classid][sequenceName] = {}
         GSE.Library[classid][sequenceName] = newSequence
@@ -204,13 +201,13 @@ function GSE.OOCPerformMergeAction(action, classid, sequenceName, newSequence)
         GSE.PrintDebugMessage(" New Entry: " .. GSE.Dump(GSE.Library[classid][sequenceName]), "Storage")
         --@end-debug@
         GSE.ComputeSequenceDependencies(GSE.Library[classid][sequenceName])
-        GSESequences[classid][sequenceName] = GSE.EncodeLike(GSESequences[classid][sequenceName], {sequenceName, GSE.Library[classid][sequenceName]})
+        GSESequences[classid][sequenceName] = GSE.EncodeMessage({sequenceName, GSE.Library[classid][sequenceName]})
         GSE.Print(sequenceName .. L[" was updated to new version."], "Storage")
     elseif action == "RENAME" then
         GSE.Library[classid][sequenceName] = {}
         GSE.Library[classid][sequenceName] = newSequence
         GSE.ComputeSequenceDependencies(GSE.Library[classid][sequenceName])
-        GSESequences[classid][sequenceName] = GSE.EncodeLike(GSESequences[classid][sequenceName], {sequenceName, GSE.Library[classid][sequenceName]})
+        GSESequences[classid][sequenceName] = GSE.EncodeMessage({sequenceName, GSE.Library[classid][sequenceName]})
         GSE.Print(sequenceName .. L[" was imported as a new sequence."], "Storage")
         --@debug@
         GSE.PrintDebugMessage(

--- a/spec/mockGSE.lua
+++ b/spec/mockGSE.lua
@@ -255,6 +255,17 @@ GSE.DecodeMessage = function (tab)
   return tab
 end
 
+-- Storage's at-rest writes go through EncodeLike (packed for noExport
+-- content, plain otherwise). The specs assert on the stored table, not on an
+-- envelope, so this mirrors the EncodeMessage stub and returns it unchanged.
+GSE.EncodeLike = function(existing, tab)
+  return tab
+end
+
+GSE.NeedsRepack = function()
+  return false
+end
+
 function C_SpellBook.FindBaseSpellByID(stuff)
   return stuff
 end

--- a/spec/mockGSE.lua
+++ b/spec/mockGSE.lua
@@ -255,6 +255,38 @@ GSE.DecodeMessage = function (tab)
   return tab
 end
 
+-- The at-rest gate lives in Serialisation.lua, which the specs do not load
+-- (they stub EncodeMessage/DecodeMessage instead). These three are pure
+-- predicates over a string and a table, so the mock carries the REAL logic
+-- rather than a stub that always says false -- otherwise every spec would
+-- exercise the unprotected branch and the gate would be untested.
+--
+-- Note the mock's EncodeMessage returns the table unchanged, so a "stored
+-- blob" in a spec is usually a table, not a string. IsPackedBlob answering
+-- false for that is correct: the protection then rests on MetaData.noExport,
+-- which is what the specs set.
+GSE.IsPackedBlob = function(blob)
+  return type(blob) == "string" and string.sub(blob, 1, 7) == "!GSE3!+"
+end
+
+GSE.IsProtectedContent = function(obj)
+  if type(obj) ~= "table" then return false end
+  local meta = obj.MetaData
+  if type(meta) ~= "table" and type(obj[2]) == "table" then meta = obj[2].MetaData end
+  return type(meta) == "table" and meta.noExport and true or false
+end
+
+GSE.IsProtectedAtRest = function(blob, obj)
+  return GSE.IsPackedBlob(blob) or GSE.IsProtectedContent(obj)
+end
+
+-- SequenceDelta.lua is not loaded either. Returning false sends the protected
+-- branch down its documented fallback -- a repack request -- which is the
+-- behaviour the specs assert on.
+GSE.SeedDeltaFork = function()
+  return false
+end
+
 function C_SpellBook.FindBaseSpellByID(stuff)
   return stuff
 end

--- a/spec/mockGSE.lua
+++ b/spec/mockGSE.lua
@@ -255,17 +255,6 @@ GSE.DecodeMessage = function (tab)
   return tab
 end
 
--- Storage's at-rest writes go through EncodeLike (packed for noExport
--- content, plain otherwise). The specs assert on the stored table, not on an
--- envelope, so this mirrors the EncodeMessage stub and returns it unchanged.
-GSE.EncodeLike = function(existing, tab)
-  return tab
-end
-
-GSE.NeedsRepack = function()
-  return false
-end
-
 function C_SpellBook.FindBaseSpellByID(stuff)
   return stuff
 end

--- a/spec/packedatrest_spec.lua
+++ b/spec/packedatrest_spec.lua
@@ -1,0 +1,251 @@
+---@diagnostic disable: undefined-global
+-- GSE decrypts the packed (!GSE3!+) envelope so it can run a macro; it never
+-- produces one. Every at-rest write therefore has to answer the same question
+-- first -- "would this put protected content on disk in the clear?" -- and
+-- decline if the answer is yes. #2054 is what happens when one of them does
+-- not: an imported protected sequence was rewritten plain during the very
+-- import that stored it sealed.
+describe(
+  "Packed content at rest",
+  function()
+    setup(
+      function()
+        require("../spec/mockGSE")
+        require("../GSE/API/Statics")
+        require("../GSE/API/InitialOptions")
+        require("../GSE/API/StringFunctions")
+        require("../GSE/API/CharacterFunctions")
+        require("../GSE/API/Storage")
+        require("../GSE/API/translator")
+        Statics = GSE.Static
+
+        GSE.ComputeSequenceDependencies = function() end
+        GSE.SnapshotDependentMacros = function() end
+        GSE.SanitizeSequenceEditorMarkup = function() return false end
+        GSE.UpdateDeltaFork = nil
+        GSE.Library = GSE.Library or {}
+        GSE.Library[1] = GSE.Library[1] or {}
+        _G.GSESequences = _G.GSESequences or {}
+        _G.GSESequences[1] = _G.GSESequences[1] or {}
+        if not GSE.SendMessage then
+          GSE.SendMessage = function() end
+        end
+
+        -- GSE.GetTimestamp goes through GetServerTime, which the mock does not
+        -- carry. A COUNTER rather than a constant, so "keeps the first
+        -- sighting's timestamp" is proving something: every call returns a
+        -- different value, and the assertion only holds if the stamp was
+        -- genuinely not refreshed.
+        local clock = 1700000000
+        _G.GetServerTime = function()
+          clock = clock + 1
+          return clock
+        end
+        -- RenameSequence walks the per-character actionbar overrides and
+        -- checks combat before touching the in-game macro.
+        _G.GSE_C = _G.GSE_C or {}
+        if not _G.InCombatLockdown then
+          _G.InCombatLockdown = function() return false end
+        end
+      end
+    )
+
+    before_each(
+      function()
+        _G.GSERepackQueue = {}
+        _G.GSESequences[1] = {}
+        GSE.Library[1] = {}
+      end
+    )
+
+    -- A real sealed blob is a string with the packed prefix. The mock's
+    -- EncodeMessage returns tables, so a string in GSESequences is unambiguous
+    -- evidence about which branch ran.
+    local SEALED = "!GSE3!+1SEALEDBLOBSTANDIN"
+
+    local function protectedSeq(name)
+      return {
+        MetaData = {Default = 1, Name = name, noExport = true, PlatformID = "pid-" .. name},
+        Versions = {{Actions = {}}},
+      }
+    end
+
+    local function ownSeq(name)
+      return {
+        MetaData = {Default = 1, Name = name},
+        Versions = {{Actions = {}}},
+      }
+    end
+
+    describe(
+      "GSE.ReplaceSequence",
+      function()
+        it(
+          "leaves the sealed blob alone when the content is protected",
+          function()
+            local seq = protectedSeq("Prot")
+            _G.GSESequences[1]["Prot"] = SEALED
+            GSE.ReplaceSequence(1, "Prot", seq)
+            assert.equals(SEALED, _G.GSESequences[1]["Prot"])
+          end
+        )
+
+        it(
+          "asks for a repack when the edit cannot be persisted",
+          function()
+            -- SeedDeltaFork is stubbed false in the mock, so this is the
+            -- documented fallback: say so rather than write it out plain.
+            local seq = protectedSeq("Prot")
+            _G.GSESequences[1]["Prot"] = SEALED
+            GSE.ReplaceSequence(1, "Prot", seq)
+            local req = _G.GSERepackQueue["sequence:1:Prot"]
+            assert.is_not_nil(req)
+            assert.equals("pid-Prot", req.platformId)
+            assert.equals("edit-needs-repack", req.reason)
+          end
+        )
+
+        it(
+          "still applies the edit in memory",
+          function()
+            local seq = protectedSeq("Prot")
+            seq.Versions[1].Actions = {"changed"}
+            _G.GSESequences[1]["Prot"] = SEALED
+            GSE.ReplaceSequence(1, "Prot", seq)
+            assert.equals("changed", GSE.Library[1]["Prot"].Versions[1].Actions[1])
+          end
+        )
+
+        it(
+          "replaces normally when the content is the author's own",
+          function()
+            -- The delta path is for protected content ONLY; an ordinary save
+            -- must keep going straight to the store, unchanged.
+            local seq = ownSeq("Mine")
+            GSE.ReplaceSequence(1, "Mine", seq)
+            assert.is_not_nil(_G.GSESequences[1]["Mine"])
+            assert.is_nil(_G.GSERepackQueue["sequence:1:Mine"])
+          end
+        )
+
+        it(
+          "declines to overwrite a sealed blob even for unmarked content",
+          function()
+            -- The envelope alone is enough. A body whose noExport was stripped
+            -- must not be able to talk GSE into rewriting the blob plain.
+            local seq = ownSeq("Sealed")
+            _G.GSESequences[1]["Sealed"] = SEALED
+            GSE.ReplaceSequence(1, "Sealed", seq)
+            assert.equals(SEALED, _G.GSESequences[1]["Sealed"])
+          end
+        )
+      end
+    )
+
+    describe(
+      "GSE.RenameSequence",
+      function()
+        it(
+          "asks for a repack rather than dropping a sequence with no stored blob",
+          function()
+            -- Assigning the missing blob across would have removed the
+            -- sequence from storage entirely.
+            local seq = protectedSeq("Old")
+            _G.GSESequences[1]["Old"] = nil
+            GSE.Library[1]["Old"] = seq
+            GSE.RenameSequence(1, "Old", "New", seq)
+            assert.is_nil(_G.GSESequences[1]["New"])
+            assert.equals("rename-needs-repack", _G.GSERepackQueue["sequence:1:New"].reason)
+          end
+        )
+
+        it(
+          "moves the sealed blob to the new key untouched",
+          function()
+            -- A rename is a change of table key, so the blob travels as the
+            -- string it already is and nothing needs encoding.
+            local seq = protectedSeq("Old")
+            _G.GSESequences[1]["Old"] = SEALED
+            GSE.Library[1]["Old"] = seq
+            GSE.RenameSequence(1, "Old", "New", seq)
+            assert.equals(SEALED, _G.GSESequences[1]["New"])
+            assert.is_nil(_G.GSESequences[1]["Old"])
+          end
+        )
+      end
+    )
+
+    describe(
+      "GSE.AuditProtectedAtRest",
+      function()
+        it(
+          "reports protected content found sitting in the clear",
+          function()
+            -- The damage a shipped build already did. It cannot be repaired
+            -- here, so it is reported for the Companion to put right.
+            GSE.AuditProtectedAtRest("sequence", 1, "Bare", {"Bare", protectedSeq("Bare")},
+              protectedSeq("Bare"))
+            local req = _G.GSERepackQueue["sequence:1:Bare"]
+            assert.is_not_nil(req)
+            assert.equals("plaintext-at-rest", req.reason)
+          end
+        )
+
+        it(
+          "clears the request once the blob is sealed again",
+          function()
+            -- This is what makes the queue self-draining: after the Companion
+            -- writes the sealed blob back, the next login removes the entry.
+            GSE.AuditProtectedAtRest("sequence", 1, "Bare", nil, protectedSeq("Bare"))
+            assert.is_not_nil(_G.GSERepackQueue["sequence:1:Bare"])
+            GSE.AuditProtectedAtRest("sequence", 1, "Bare", SEALED, protectedSeq("Bare"))
+            assert.is_nil(_G.GSERepackQueue["sequence:1:Bare"])
+          end
+        )
+
+        it(
+          "says nothing about the author's own content",
+          function()
+            GSE.AuditProtectedAtRest("sequence", 1, "Mine", nil, ownSeq("Mine"))
+            assert.is_nil(_G.GSERepackQueue["sequence:1:Mine"])
+          end
+        )
+
+        it(
+          "keeps the first sighting's timestamp across repeated logins",
+          function()
+            GSE.AuditProtectedAtRest("sequence", 1, "Bare", nil, protectedSeq("Bare"))
+            local first = _G.GSERepackQueue["sequence:1:Bare"].stamp
+            GSE.AuditProtectedAtRest("sequence", 1, "Bare", nil, protectedSeq("Bare"))
+            assert.equals(first, _G.GSERepackQueue["sequence:1:Bare"].stamp)
+            -- and one entry, not two
+            local n = 0
+            for _ in pairs(_G.GSERepackQueue) do n = n + 1 end
+            assert.equals(1, n)
+          end
+        )
+      end
+    )
+
+    describe(
+      "GSE.BackfillLastUpdated",
+      function()
+        it(
+          "skips protected content instead of stamping it",
+          function()
+            -- There is no way to persist the stamp without rewriting the
+            -- sealed blob, and an unwritten one would be re-minted to a new
+            -- `now` on every load -- drift, not a backfill.
+            local seq = protectedSeq("Prot")
+            seq.LastUpdated = nil
+            _G.GSESequences[1]["Prot"] = SEALED
+            GSE.Library[1]["Prot"] = seq
+            GSE.BackfillLastUpdated()
+            assert.is_nil(seq.LastUpdated)
+            assert.equals(SEALED, _G.GSESequences[1]["Prot"])
+          end
+        )
+      end
+    )
+  end
+)

--- a/spec/run51.lua
+++ b/spec/run51.lua
@@ -91,6 +91,24 @@ function luassert.is_truthy(v, msg) if not v then error((msg or "") .. " expecte
 function luassert.is_falsy(v, msg) if v then error((msg or "") .. " expected falsy, got " .. tostring(v), 2) end end
 luassert.truthy, luassert.falsy = luassert.is_truthy, luassert.is_falsy
 
+-- assert.is_not.equals(a, b) / assert.is_not.same(a, b). busted has the whole
+-- negated namespace; the specs use these, so the shim carries them rather than
+-- the specs working around a gap that only exists under 5.1.
+luassert.is_not = {
+  equals = function(expected, actual, msg)
+    if expected == actual then
+      error((msg or "") .. " expected anything but " .. render(expected), 2)
+    end
+  end,
+  same = function(expected, actual, msg)
+    if deepEqual(expected, actual) then
+      error((msg or "") .. " expected anything but " .. render(expected), 2)
+    end
+  end,
+}
+luassert.is_not.equal = luassert.is_not.equals
+luassert.are_not = luassert.is_not
+
 -- assert.has.errors(fn) / assert.has_no.errors(fn)
 luassert.has = {
   errors = function(fn, msg)


### PR DESCRIPTION
Fixes #2054.

GSE can decrypt `!GSE3!+` but had no way to produce one — `EncodeMessage` only emits plain — so any path that re-encoded a stored blob downgraded it. Since #2045, `StampOriginKey` fires on every first load, so it happened on import, every time.

## Change

**`GSE.EncodePackedMessage` (Codec.lua)** — the inverse of `DecodePackedMessage`, same layout, same key table. ChaCha20 is a stream cipher so it is the same `TransformBytes` call in the other direction. It lives in `Codec.lua` because `keys` is file-local.

**`GSE.EncodeLike(existing, tab)` (Serialisation.lua)** — what the 13 at-rest writes now call instead of `EncodeMessage`. The envelope follows one fact: `MetaData.noExport`.

| Content | Stored as |
|---|---|
| Protected (`noExport`) | `!GSE3!+` |
| The author's own | plain `!GSE3!` — unchanged from today |

Deliberately **not** inherited from what was on disk: inheriting makes the envelope sticky, so a blob packed by mistake could never return to plain.

**`GSE.NeedsRepack`** heals both directions on load, so a library already downgraded by an earlier build repairs itself rather than staying exposed.

**Why only protected content.** The Companion desktop app decodes `GSE.lua` directly and is deliberately blind to `!GSE3!+` ("opaque to the Companion by design — no key", `wow.js:438`); it reads `GSESequences` for change detection, Replace-mine author detection and deletes. Packing everything breaks all three. Packing only protected content is exactly what the Companion already ignores, so it needs no change and the key stays in one binary. This also matches the existing contract: content fetched through the Companion arrives plain for your own work and packed for other people's.

Wire and export encodes are untouched and still plain (`Serialisation:95`, `Export.lua:31`, `Utils.lua:1838`).

## Tested in-game (Retail)

- Import the `TL_PROT` collection → stays `!GSE3!+1`; decrypted content byte-identical to the site payload (Versions canonically identical; Icon 67/67, macro 87/87, Type 99/99, target 61/61).
- A library already downgraded heals on next login: 153 own sequences plain, `TL_PROT` + `KnownSpell` (both `noExport`) packed; 154/154 round-trip identical, 0 undecodable.
- Edit an own sequence → Save → `/reload` sticks; sequences fire in combat; Companion Bridge loads and connects; plugin packs register.
- With the fix in place a third-party converter that had been reading the plaintext could no longer read the protected sequence, and `GSE.lua` was byte-identical to a pre-run backup.

## One caveat, stated plainly

The ChaCha20 key ships in `Codec.lua` and is symmetric, so `!GSE3!+` is obfuscation, not cryptography — anyone who copies that file can decrypt. That is not fixable while the addon must decrypt locally to run a macro. What this restores is the boundary: protected content is no longer lying in the clear for anything that opens the file, and a tool now has to deliberately decrypt content marked `noExport`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)