### PR TITLE
Refuse wowlazymacros.com as a Help Link, and heal stored sequences (#2059)

### DIFF
--- a/GSE/API/Storage.lua
+++ b/GSE/API/Storage.lua
@@ -159,6 +159,25 @@ function GSE.AuditProtectedAtRest(contentType, classid, name, blob, obj)
     return true
 end
 
+--- Help links may not point at wowlazymacros.com in any form -- any scheme,
+--- subdomain, path or case.  Shared by the editor's Help Link box and the
+--- load-time migration, so a sequence already carrying one is healed the
+--- first time it is loaded, the way StampOriginKey backfills OriginKey.
+GSE.HelplinkDefault = "https://discord.gg/gseunited"
+GSE.HelplinkBlockedHost = "wowlazymacros.com"
+function GSE.HelplinkAllowed(link)
+    if GSE.isEmpty(link) then return true end
+    return not string.find(string.lower(tostring(link)), GSE.HelplinkBlockedHost, 1, true)
+end
+--- Replace a disallowed MetaData.Helplink with the default.  Returns true if
+--- it wrote.
+function GSE.SanitizeHelplink(sequence)
+    if type(sequence) ~= "table" or type(sequence.MetaData) ~= "table" then return false end
+    if GSE.HelplinkAllowed(sequence.MetaData.Helplink) then return false end
+    sequence.MetaData.Helplink = GSE.HelplinkDefault
+    return true
+end
+
 local function migrateSequenceVersions(sequence, sequenceName)
     if type(sequence) ~= "table" then return false end
     if sequence["Macros"] ~= nil and sequence.Versions == nil then
@@ -178,6 +197,7 @@ local function migrateSequenceVersions(sequence, sequenceName)
     if GSE.SanitizeSequenceEditorMarkup and GSE.SanitizeSequenceEditorMarkup(sequence) then
         changed = true
     end
+    if GSE.SanitizeHelplink(sequence) then changed = true end
     if changed and type(sequence.MetaData) == "table" then
         sequence.MetaData.Checksum = nil
     end
@@ -645,6 +665,7 @@ function GSE.ReplaceSequence(classid, sequenceName, sequence)
     -- than acquiring it whenever it is next read back. Idempotent -- an
     -- existing stamp is left alone.
     GSE.StampOriginKey(sequence, sequenceName)
+    GSE.SanitizeHelplink(sequence)
     GSE.ComputeSequenceDependencies(sequence)
     GSE.SnapshotDependentMacros(sequence)
     if GSE.UpdateDeltaFork and GSE.UpdateDeltaFork(sequence) then

--- a/GSE_GUI/Editor_Metadata.lua
+++ b/GSE_GUI/Editor_Metadata.lua
@@ -621,6 +621,11 @@ local function addAuthorEditor(editframe, container)
     container:AddChild(authoreditbox)
 end
 
+-- The rule itself (which host, what replaces it) lives in Storage.lua with
+-- the load-time heal; this box only applies it as you type.
+local HELPLINK_DEFAULT = GSE.HelplinkDefault
+local helplinkAllowed = GSE.HelplinkAllowed
+
 local function addHelpLinkEditor(editframe, container)
     local helplinkeditbox = UI:Create("EditBox")
     helplinkeditbox:SetLabel(T("Help Link"))
@@ -644,13 +649,20 @@ local function addHelpLinkEditor(editframe, container)
         end
     )
 
-    if GSE.isEmpty(editframe.Sequence.MetaData.Helplink) then
-        editframe.Sequence.MetaData.Helplink = "https://discord.gg/gseunited"
+    if GSE.isEmpty(editframe.Sequence.MetaData.Helplink) or not helplinkAllowed(editframe.Sequence.MetaData.Helplink) then
+        editframe.Sequence.MetaData.Helplink = HELPLINK_DEFAULT
     end
     helplinkeditbox:SetText(editframe.Sequence.MetaData.Helplink)
     helplinkeditbox:SetCallback(
         "OnTextChanged",
         function(obj, event, key)
+            if not helplinkAllowed(key) then
+                -- SetText re-fires this callback with the default, which
+                -- passes, so there is no loop.
+                editframe.Sequence.MetaData.Helplink = HELPLINK_DEFAULT
+                helplinkeditbox:SetText(HELPLINK_DEFAULT)
+                return
+            end
             editframe.Sequence.MetaData.Helplink = key
         end
     )

--- a/spec/storage_spec.lua
+++ b/spec/storage_spec.lua
@@ -113,5 +113,43 @@ describe(
       end
     )
 
+    describe(
+      "help link sanitising",
+      function()
+        it(
+          "refuses wowlazymacros.com in any scheme, subdomain, path or case",
+          function()
+            assert.is_false(GSE.HelplinkAllowed("https://wowlazymacros.com/"))
+            assert.is_false(GSE.HelplinkAllowed("HTTP://WWW.WowLazyMacros.COM/some/page"))
+            assert.is_false(GSE.HelplinkAllowed("wowlazymacros.com"))
+            assert.is_true(GSE.HelplinkAllowed("https://discord.gg/gseunited"))
+            assert.is_true(GSE.HelplinkAllowed(""))
+            assert.is_true(GSE.HelplinkAllowed(nil))
+          end
+        )
+
+        it(
+          "heals a stored sequence to the default and reports the write",
+          function()
+            local seq = {MetaData = {Helplink = "https://www.wowlazymacros.com/x"}, Versions = {}}
+            assert.is_true(GSE.SanitizeHelplink(seq))
+            assert.are.equal(GSE.HelplinkDefault, seq.MetaData.Helplink)
+            assert.is_false(GSE.SanitizeHelplink(seq))
+          end
+        )
+
+        it(
+          "leaves an allowed link and non-sequences alone",
+          function()
+            local seq = {MetaData = {Helplink = "https://example.org/help"}, Versions = {}}
+            assert.is_false(GSE.SanitizeHelplink(seq))
+            assert.are.equal("https://example.org/help", seq.MetaData.Helplink)
+            assert.is_false(GSE.SanitizeHelplink(nil))
+            assert.is_false(GSE.SanitizeHelplink({}))
+          end
+        )
+      end
+    )
+
   end
 )


### PR DESCRIPTION
Fixes #2059.

### What

- `GSE.HelplinkAllowed(link)` / `GSE.SanitizeHelplink(sequence)` in `Storage.lua`: a plain lower-cased substring match on `wowlazymacros.com`, so every scheme, subdomain, path and case is caught (and nothing like `wowlazymacros.com.other.tld` slips past). A match becomes `https://discord.gg/gseunited`.
- Runs in three places:
  - **on load**, inside `migrateSequenceVersions` beside `StampOriginKey`, so sequences already in SavedVariables are healed the first time they load; it reports `changed`, so the checksum is cleared and the healed copy is what gets re-encoded — the same path every other load-time heal takes;
  - **on store**, beside the store-side `StampOriginKey`;
  - **in the editor's Help Link box** as you type — the box snaps back to the default, silently.
- `spec/storage_spec.lua`: three cases covering the matcher (case / scheme / path / empty / nil), the heal writing once and reporting it, and allowed links and non-sequences being left alone.

### Data model

Unchanged. Only `MetaData.Helplink`'s value is touched, and only when it matches.

Verified in game on Retail 12.1.0, both paths: typing `HTTPS://WWW.WowLazyMacros.com/anything` snaps back to the default, and a sequence saved with a wowlazymacros.com link reopens after `/reload` with the default — the load-time heal against a live SavedVariables file. Larry drove the requirement and did the verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


