### PR TITLE
Block icon: prefer the first unconditional cast line (#2061)

### DIFF
--- a/GSE_GUI/Editor.lua
+++ b/GSE_GUI/Editor.lua
@@ -1428,12 +1428,39 @@ local function isMacroLineFormOrStance(line)
     return isFormSpellCandidate(getMacroLineResolvedIconCandidate(line))
 end
 
+-- A macro line whose cast is gated on a conditional -- "/cast [mod:alt] X".
+-- A bracket group before the spell means the line only fires in that state,
+-- so it does not represent what the block normally does.  Comment lines and
+-- the target-only form "/cast [@player]" are not conditionals in this sense,
+-- but the bracket test does not need to tell them apart: any bracketed line
+-- loses to an unbracketed one, and if every line is bracketed the original
+-- first-line order still decides.
+local function isMacroLineConditional(line)
+    if type(line) ~= "string" then return false end
+    -- Strip the command word, then look for a bracket group before anything
+    -- else: "/cast [mod:alt] X" yes, "/cast Mortal Strike" no.
+    local remainder = string.match(line, "^%s*/%a+%s+(.*)$")
+    if not remainder then return false end
+    return string.match(remainder, "^%[") ~= nil
+end
+
+-- The icon a macro block shows.  Two passes: the first takes the first line
+-- that is NOT gated on a conditional, because a block that opens with a
+-- string of "[mod:...]" lines and ends in its real cast should show the real
+-- cast -- otherwise every block sharing the same modifier preamble draws the
+-- same icon.  The second pass is the original behaviour, for macros where
+-- every line is conditional.
 local function getFirstMacroLineIconInfo(macro, skipForms)
-    for _, line in ipairs(GSE.SplitMeIntoLines(macro or "")) do
-        if not (skipForms and isMacroLineFormOrStance(line)) then
-            local spellinfo = GSE.GetSpellsFromString(line, true)
-            local iconInfo = getMacroLineResolvedIconInfo(line, skipForms) or getFirstIconInfo(spellinfo, skipForms) or getMacroLineFallbackIconInfo(line, skipForms)
-            if iconInfo then return iconInfo end
+    local lines = GSE.SplitMeIntoLines(macro or "")
+    for pass = 1, 2 do
+        for _, line in ipairs(lines) do
+            local skip = (skipForms and isMacroLineFormOrStance(line)) or
+                (pass == 1 and isMacroLineConditional(line))
+            if not skip then
+                local spellinfo = GSE.GetSpellsFromString(line, true)
+                local iconInfo = getMacroLineResolvedIconInfo(line, skipForms) or getFirstIconInfo(spellinfo, skipForms) or getMacroLineFallbackIconInfo(line, skipForms)
+                if iconInfo then return iconInfo end
+            end
         end
     end
 end


### PR DESCRIPTION
Fixes #2061.

### Change

`getFirstMacroLineIconInfo` runs two passes over the macro's lines:

1. skip any line whose cast is gated on a bracket conditional (`isMacroLineConditional`), and
2. if nothing resolved, fall back to the original order.

So a block that opens with `[mod:...]` lines and ends in its real cast shows the real cast, while a macro where every line is conditional keeps exactly the icon it picks today.

`isMacroLineConditional` strips the command word and tests for a leading bracket group, so `/cast [mod:alt] X` is conditional and `/cast Mortal Strike` is not. `#showtooltip`, `/use 13` and empty lines are not conditionals; `/cast [@player] X` is treated as one, which is harmless — a bracketed line only ever loses to an unbracketed one, and when they are all bracketed the original order still decides.

Nothing else in the icon rules moves: `IconUserSelected` still wins, question-mark icons are still treated as unresolved and retried, form/stance handling and `shouldReplaceFormActionIcon` are untouched, and the variable / in-game-macro categories are unchanged.

### Verification

The detector was unit-tested standalone against 9 cases (each `[mod:]` form, plain casts, `[@player]`, `/castsequence [combat]`, `#showtooltip`, `/use 13`, empty) — all pass. `luac -p` clean.

Verified in game on Retail 12.1.0: the Warrior blocks in the issue now draw Mortal Strike / Whirlwind / Overpower instead of all showing Impending Victory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

