### PR TITLE
Macros: sealed iff protected, never because of the envelope (#2063)

### DIFF
--- a/GSE/API/Serialisation.lua
+++ b/GSE/API/Serialisation.lua
@@ -29,6 +29,9 @@ function GSE.IsProtectedContent(obj)
     if type(meta) ~= "table" and type(obj[2]) == "table" then meta = obj[2].MetaData end
     return type(meta) == "table" and meta.noExport and true or false
 end
+--- The same test, for the macro store: packed iff MetaData.noExport, never
+--- inherited from the envelope it arrived in.  One rule for all three stores.
+GSE.IsProtectedContent = isProtected
 
 --- The gate every at-rest write consults. True means "leave the stored blob
 -- exactly as it is".

--- a/GSE/API/Storage.lua
+++ b/GSE/API/Storage.lua
@@ -715,6 +715,17 @@ function GSE.StoreEncodedMacro(name, encoded)
         GSE.Print(L["Unable to interpret sequence."] .. " " .. name, GNOME)
         return false
     end
+    -- The envelope a macro arrived in does not decide how it rests -- the
+    -- same rule as sequences and variables does: sealed iff the content is
+    -- protected.  The author's own macro, which the site ships pre-encoded
+    -- like everything else, is stored plain, exactly as if it had arrived as
+    -- a table (#2054's rule, applied to the one store that missed it).
+    if not (GSE.IsProtectedContent and GSE.IsProtectedContent(decoded)) then
+        decoded.objectType = nil
+        if not decoded.name then decoded.name = name end
+        GSE.ImportMacro(decoded)
+        return true
+    end
     if GSE.isEmpty(GSEMacros) then GSEMacros = {} end
     GSEMacros[name] = { GSEProtected = encoded }
     if GSE.ManageMacros then GSE.ManageMacros() end
@@ -3101,6 +3112,20 @@ local function resolveMacroNode(entry)
     return entry, false
 end
 
+--- Self-heal for the macro store, mirroring NeedsRepack for sequences and
+--- variables: an entry sealed on receipt that is NOT protected content is
+--- the author's own macro and must rest plain, or the Companion (which has
+--- no key) cannot see it.  Returns the plain node to carry on with, or nil
+--- when the entry is genuinely protected and stays sealed.
+local function unsealOwnMacro(bucket, name, node)
+    if type(node) ~= "table" then return nil end
+    if GSE.IsProtectedContent and GSE.IsProtectedContent(node) then return nil end
+    node.objectType = nil
+    if not node.name then node.name = name end
+    bucket[name] = node
+    return node
+end
+
 local function materialiseEncodedMacro(name, node, category)
     if not node then return end
     local text = node.managedMacro or node.text
@@ -3258,8 +3283,10 @@ function GSE.ManageMacros()
         local pnode, encodedEntry = resolveMacroNode(v)
         if encodedEntry then
             -- Entry held in received encoded form: materialise without writing
-            -- a plaintext node back over it (see resolveMacroNode).
+            -- a plaintext node back over it (see resolveMacroNode) -- unless
+            -- it is the author's own, which is unsealed to rest plain.
             materialiseEncodedMacro(k, pnode, nil)
+            unsealOwnMacro(GSEMacros, k, pnode)
         elseif v.Managed then
             local macroIndex = GetMacroIndexByName(k)
             if macroIndex ~= v.value then
@@ -3311,6 +3338,7 @@ function GSE.ManageMacros()
                 local cpnode, cEncodedEntry = resolveMacroNode(v)
                 if cEncodedEntry then
                     materialiseEncodedMacro(k, cpnode, true)
+                    unsealOwnMacro(GSEMacros[char .. "-" .. realm], k, cpnode)
                 elseif v.Managed then
                     local macroIndex = GetMacroIndexByName(k)
                     if macroIndex ~= v.value then

--- a/spec/mockGSE.lua
+++ b/spec/mockGSE.lua
@@ -255,6 +255,16 @@ GSE.DecodeMessage = function (tab)
   return tab
 end
 
+
+-- Storage's macro store asks the same question EncodeLike answers: is this
+-- protected content (MetaData.noExport)?  Same shape as the real one in
+-- Serialisation.lua, which the specs never load.
+GSE.IsProtectedContent = function(tab)
+    local meta = type(tab) == "table"
+        and (tab.MetaData or (type(tab[2]) == "table" and tab[2].MetaData))
+    return type(meta) == "table" and meta.noExport and true or false
+end
+
 -- The at-rest gate lives in Serialisation.lua, which the specs do not load
 -- (they stub EncodeMessage/DecodeMessage instead). These three are pure
 -- predicates over a string and a table, so the mock carries the REAL logic

--- a/spec/storage_spec.lua
+++ b/spec/storage_spec.lua
@@ -113,5 +113,65 @@ describe(
       end
     )
 
+    describe(
+      "macro rest shape",
+      function()
+        local realDecode, realImport, realManage, imported
+        before_each(
+          function()
+            realDecode, realImport, realManage = GSE.DecodeMessage, GSE.ImportMacro, GSE.ManageMacros
+            imported = nil
+            -- The sealed path refreshes the macro book afterwards; that is
+            -- the WoW API's business, not this test's.
+            GSE.ManageMacros = function() end
+            if not GSE.SendMessage then GSE.SendMessage = function() end end
+            -- "encoded" strings decode to the table they name, so a case can
+            -- hand StoreEncodedMacro whatever content it wants to test.
+            GSE.DecodeMessage = function(blob)
+              if blob == "own" then return true, {name = "Own", text = "/cast X", icon = 1} end
+              if blob == "sealed" then return true, {name = "Sealed", text = "/cast Y", MetaData = {noExport = true}} end
+              return false
+            end
+            GSE.ImportMacro = function(node) imported = node end
+            GSEMacros = {}
+          end
+        )
+        after_each(
+          function()
+            GSE.DecodeMessage, GSE.ImportMacro, GSE.ManageMacros = realDecode, realImport, realManage
+          end
+        )
+
+        it(
+          "stores the author's own macro plain, however it arrived",
+          function()
+            assert.is_true(GSE.StoreEncodedMacro("Own", "own"))
+            assert.is_not_nil(imported)
+            assert.are.equal("Own", imported.name)
+            assert.are.equal("/cast X", imported.text)
+            assert.is_nil(GSEMacros["Own"])
+          end
+        )
+
+        it(
+          "keeps protected content sealed",
+          function()
+            assert.is_true(GSE.StoreEncodedMacro("Sealed", "sealed"))
+            assert.is_nil(imported)
+            assert.are.same({GSEProtected = "sealed"}, GSEMacros["Sealed"])
+          end
+        )
+
+        it(
+          "refuses a blob it cannot read",
+          function()
+            assert.is_false(GSE.StoreEncodedMacro("Bad", "garbage"))
+            assert.is_nil(imported)
+            assert.is_nil(GSEMacros["Bad"])
+          end
+        )
+      end
+    )
+
   end
 )


### PR DESCRIPTION
Fixes #2063.

### Change

#2054's rule — *packed iff `MetaData.noExport`, never inherited from the envelope* — applied to the one store that missed it.

- `Serialisation.lua`: the existing `isProtected` is exported as `GSE.IsProtectedContent`, so all three stores share one test.
- `Storage.lua` `StoreEncodedMacro`: an unprotected macro now takes the same plain `ImportMacro` path the Companion's table branch uses. The wire shape no longer decides. Protected content still rests as `{GSEProtected = …}`.
- `Storage.lua` `ManageMacros`: `unsealOwnMacro()` after each sealed entry is materialised, in both the account bucket and the char-realm bucket — the missing `NeedsRepack` counterpart, so an already-sealed own macro rests plain on the next pass with no re-import.
- `spec/`: `mockGSE` gains an `IsProtectedContent` shim; `storage_spec` adds three cases on the rest shape — own → plain via `ImportMacro`, protected → stays sealed, unreadable blob → `false`.

### Data model

Unchanged. `GSEMacros` keeps both of its existing shapes; only *which* shape an entry takes is now decided by the same test the other two stores use.

### Verified in game (Retail 12.1.0)

Before: `GSEMacros["SLG-FesteringSTK"] = { GSEProtected = "!GSE3!+1…" }`, zero plain fields.
After two reloads (one to run the heal on `PLAYER_ENTERING_WORLD`, one to flush the saved file): a plain table with `name`, `value = 41`, `text`, `icon = 879926`, `manageMacro`; zero `GSEProtected` entries left in `GSEMacros`; the macro present in the macro book at slot 41. No errors logged. Larry drove the requirement and did the verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
