### PR TITLE
Editor: read a locally-edited sequence back through its delta fork

### DIFF
--- a/GSE_GUI/Editor.lua
+++ b/GSE_GUI/Editor.lua
@@ -8143,9 +8143,14 @@ function GSE.GUILoadEditor(editor, key, recordedstring)
     -- BASE. Storage's two load paths already prefer the reconstruction; the
     -- editor has to as well, or every open hands back the pristine original and
     -- the user's edit looks like it was never saved.
+    -- Cloned, not adopted. What comes back is the editor's working copy and it
+    -- is mutated from here on -- WeakAuras is defaulted immediately below, and
+    -- everything the user then does in the editor writes through it. Taking the
+    -- reconstruction directly would make those edits land in whatever table the
+    -- fork was rebuilt into, before the user has pressed anything.
     if sequence and GSE.ApplyStoredDeltaFork then
         local forked = GSE.ApplyStoredDeltaFork(sequence)
-        if forked then sequence = forked end
+        if forked then sequence = GSE.CloneSequence(forked) end
     end
 
     if GSE.isEmpty(sequence.WeakAuras) then

--- a/GSE_GUI/Editor.lua
+++ b/GSE_GUI/Editor.lua
@@ -8138,6 +8138,15 @@ function GSE.GUILoadEditor(editor, key, recordedstring)
     if seq then
         sequence = seq[2]
     end
+    -- An edit to protected content is stored as a delta over the sealed blob,
+    -- never written back into GSESequences, so the stored blob is only ever the
+    -- BASE. Storage's two load paths already prefer the reconstruction; the
+    -- editor has to as well, or every open hands back the pristine original and
+    -- the user's edit looks like it was never saved.
+    if sequence and GSE.ApplyStoredDeltaFork then
+        local forked = GSE.ApplyStoredDeltaFork(sequence)
+        if forked then sequence = forked end
+    end
 
     if GSE.isEmpty(sequence.WeakAuras) then
         sequence.WeakAuras = {}


### PR DESCRIPTION
Fixes #2068

An edit to sealed content is deliberately never written into `GSESequences`. `ReplaceSequence` diverts it into a delta fork instead, keeping the sealed blob as the base — so for that content the stored blob is only ever the STARTING POINT, and the edit lives in `GSEDeltas` beside it.

Storage's two load paths already know this and prefer the reconstruction (`loadOneClass` and `EnsureSequenceLoaded` both call `GSE.ApplyStoredDeltaFork`). `GUILoadEditor` did not. It decodes `GSESequences[classid][sequenceName]` straight into `editframe.Sequence`, so opening a sequence handed back the pristine original every time and the user's own edit looked like it had never saved.

`GUILoadEditor` is the only entry point for opening a sequence, so every open was affected.

### This is not about ownership

Worth stressing, because the symptom is much broader than "content someone else made". A web export is sealed for everybody **including the owner** — the site cannot prove who is pasting a string, so it hands out `!GSE3!+` regardless. `GSE.ImportSerialisedSequence` then stores that string verbatim by design.

So the everyday path that hits this is: export your own sequence from gse.tools, paste it into Import, edit it. It presents as "GSE will not let me edit my own sequences", which is why it reads as the addon being broken rather than as a protection rule.

### The save side was always fine

From a live SavedVariables file after editing three manually imported sequences:

```
GSEDeltas: 3 forks stored
   69e6f738611d1bfb100c4f4c   base !GSE3!+... (1248 bytes, SEALED)   delta 1660 bytes
   69e6f739611d1bfb100c4f7f   base !GSE3!+... (1328 bytes, SEALED)   delta 1488 bytes
   6a942505618f33a9c07b50cf   base !GSE3!+... (1284 bytes, SEALED)   delta 1880 bytes
GSERepackQueue = nil
```

The deltas were written, the bases stayed sealed, nothing was queued for repack. Only the read was wrong.

### Verification

Checked against that real SavedVariables file: the lookup resolves the stored edit by PlatformID under both object shapes the function accepts, and returns nil for a different id, for a sequence with no id, and for nil — so no sequence can pick up another's delta.

Confirmed in game: with this applied, an edited sequence reopens with the edit intact and stays editable. Without it, on the same data, the edit is invisible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
