### PR TITLE
Scroll content: subtract the reserve the viewport is actually inset by

### DIFF
--- a/GSE_GUI/NativeUI.lua
+++ b/GSE_GUI/NativeUI.lua
@@ -3168,8 +3168,13 @@ local function createScrollFrame()
         return widget.scrollBarEnabled == false and 0 or -STYLE.scrollBarReserve
     end
 
+    -- Must subtract the SAME reserve the viewport is inset by (scrollBarInset
+    -- above, scrollBarReserve = 24), not scrollBarVisibleReserve = 18. Sizing
+    -- the content 6px wider than the window it is clipped to meant every
+    -- full-width child -- a macro block, say -- lost its right edge to
+    -- SetClipsChildren.
     local function contentWidth(width)
-        return math.max(1, (width or safeWidth(frame, widget.width or 300)) - (widget.scrollBarEnabled == false and 0 or STYLE.scrollBarVisibleReserve))
+        return math.max(1, (width or safeWidth(frame, widget.width or 300)) - (widget.scrollBarEnabled == false and 0 or STYLE.scrollBarReserve))
     end
 
     local function updateScrollFrameInset()


### PR DESCRIPTION
Fixes #2070

A scroll frame's viewport is anchored `BOTTOMRIGHT` at `-STYLE.scrollBarReserve` (24), but `contentWidth` sized the scroll child against `STYLE.scrollBarVisibleReserve` (18).

The content was therefore 6px wider than the window clipping it, and because the scroll frame sets `SetClipsChildren(true)`, every full-width child lost its right edge. It shows up most obviously on macro blocks, whose right border simply is not drawn.

Sizing the content against the same reserve the viewport is inset by puts the edge back:

```lua
- ... - (widget.scrollBarEnabled == false and 0 or STYLE.scrollBarVisibleReserve))
+ ... - (widget.scrollBarEnabled == false and 0 or STYLE.scrollBarReserve))
```

Worth flagging that this touches every scroll frame in the editor, not only macro blocks — anywhere a child was sized to the full content width, it was losing the same 6px. Verified in game on the macro blocks that prompted it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

