### PR TITLE
Add support for EllesmereUI actionbar buttons

### DIFF
--- a/GSE_GUI/Editor_Keybind.lua
+++ b/GSE_GUI/Editor_Keybind.lua
@@ -626,6 +626,14 @@ local function showKeybind(editframe, bind, button, specialization, loadout, typ
                 end
             end
         end
+        if EllesmereUI then
+            local v = "EABButton"
+            for i = 1, 180 do
+                if _G[v .. i] then
+                    buttonlist[v .. i] = v .. i
+                end
+            end
+        end
 
         -- Add any buttons referenced in saved AO data that exist in G but weren't auto-detected
         if not GSE.isEmpty(GSE_C["ActionBarBinds"]) then


### PR DESCRIPTION
## Problem

With EllesmereUI loaded, its buttons (`EABButton1` … `EABButton180`) never appear in the GSE sequence editor's Actionbar Buttons dropdown (`GSE_GUI/Editor_Keybind.lua`), so no override can be picked from the UI.

## Change

One block in `GSE_GUI/Editor_Keybind.lua`, after the ButtonForge block, same pattern as the existing entries:

```lua
if EllesmereUI then
    local v = "EABButton"
    for i = 1, 180 do
        if _G[v .. i] then
            buttonlist[v .. i] = v .. i
        end
    end
end
```

Only existing frames are listed (unbuilt slots and gaps skip via the `_G` check). No core logic touched; apply path already handles `EABButton*` (`GSE/API/Events.lua`, `GSE_Utils/Utils.lua`).
