### PR TITLE
Own content: store it plain on import, and heal what is already sealed

### DIFF
--- a/GSE/API/SequenceDelta.lua
+++ b/GSE/API/SequenceDelta.lua
@@ -339,12 +339,39 @@ end
 -- edited locally; GSEDeltas holds the divergence. A load path that assigned
 -- the decoded blob straight into the Library would silently discard the edit,
 -- so every load path asks this first and prefers what it returns.
-function GSE.ApplyStoredDeltaFork(obj)
+function GSE.ApplyStoredDeltaFork(obj, storedBlob)
     if type(GSEDeltas) ~= "table" or type(obj) ~= "table" then return nil end
     local meta = obj.MetaData or {}
     local pid = meta.PlatformID or obj.PlatformID
     if type(pid) ~= "string" or type(GSEDeltas[pid]) ~= "table" then return nil end
+    -- The fork only describes the divergence from ONE base. If the caller says
+    -- what is on disk now and it is not that base, the record has been replaced
+    -- since the fork was taken -- a re-import, or an updated copy from the
+    -- platform -- and rebuilding from the old base would resurrect the version
+    -- the user just replaced. A PlatformID is stable across those, so matching
+    -- on the id alone is not enough.
+    if storedBlob ~= nil and GSEDeltas[pid].b ~= storedBlob then return nil end
     return GSE.ReconstructDeltaFork(GSEDeltas[pid])
+end
+
+--- Drop the delta fork for `subject`, which may be the object or its
+--- PlatformID. Called whenever the thing the fork describes is removed.
+--
+-- GSEDeltas is a sidecar keyed by PlatformID, and a deleted record left its
+-- entry behind forever: nothing else ever removes one. That is litter until
+-- something is installed under the same id, at which point the stale fork is
+-- adopted and the "fresh" copy silently carries the previous edits.
+function GSE.ForgetDeltaFork(subject)
+    if type(GSEDeltas) ~= "table" then return false end
+    local pid = subject
+    if type(subject) == "table" then
+        local meta = subject.MetaData or {}
+        pid = meta.PlatformID or subject.PlatformID
+    end
+    if type(pid) ~= "string" or pid == "" then return false end
+    if GSEDeltas[pid] == nil then return false end
+    GSEDeltas[pid] = nil
+    return true
 end
 
 --- Open a delta fork for content that does not have one yet, keyed by its own

--- a/GSE/API/Serialisation.lua
+++ b/GSE/API/Serialisation.lua
@@ -47,6 +47,28 @@ function GSE.IsProtectedAtRest(blob, obj)
     return GSE.IsPackedBlob(blob) or GSE.IsProtectedContent(obj)
 end
 
+--- The form an incoming blob should be STORED in.
+--
+-- A packed envelope is what the website puts on every export, the owner's
+-- included -- it says where the string came from, not what it is. Only the
+-- body can say whether the content is protected. So a packed blob whose body
+-- does not say noExport is re-encoded plain, exactly as the addon would have
+-- written it itself; anything else -- protected, or not packed to begin with
+-- -- is returned untouched.
+--
+-- Keeping such a blob sealed was not harmless: IsProtectedAtRest reads the
+-- envelope as proof, so the user's own sequence was treated as protected on
+-- every save and each edit was diverted into a delta fork for good.
+--
+-- `plain` is the table to encode when unpacking; the caller knows the shape
+-- ({name, sequence} for a sequence, the object itself for a variable).
+function GSE.StorableForm(encoded, body, plain)
+    if GSE.IsPackedBlob(encoded) and not GSE.IsProtectedContent(body) then
+        return GSE.EncodeMessage(plain)
+    end
+    return encoded
+end
+
 -- This decodes a string into a LUA Table.  This returns a bool (success) and an object that contains the results.
 function GSE.DecodeMessage(data)
     if string.sub(data, 1, 7) == "!GSE3!+" then

--- a/GSE/API/Storage.lua
+++ b/GSE/API/Storage.lua
@@ -159,6 +159,34 @@ function GSE.AuditProtectedAtRest(contentType, classid, name, blob, obj)
     return true
 end
 
+--- The other mismatch, the mirror of the audit above: a blob still wearing the
+--- site's envelope whose body does NOT say it is protected. That is the user's
+--- own content, imported before StorableForm existed, and every save since has
+--- been diverted into a delta fork because IsProtectedAtRest reads the envelope
+--- as proof. Rewrite it plain, the way the addon writes its own.
+--
+-- `obj` must already have any delta fork applied -- the callers do that -- so
+-- the user's edits fold into the record. The fork is then retired: a plain
+-- record is saved in place from here on. Returns the plain blob, or nil when
+-- there was nothing to heal.
+function GSE.HealOwnContentAtRest(contentType, classid, name, blob, obj)
+    if not GSE.IsPackedBlob(blob) or GSE.IsProtectedContent(obj) then return nil end
+    local plain
+    if contentType == "sequence" then
+        if type(GSESequences) ~= "table" or type(GSESequences[classid]) ~= "table" then return nil end
+        plain = GSE.EncodeMessage({name, obj})
+        GSESequences[classid][name] = plain
+    elseif contentType == "variable" then
+        if type(GSEVariables) ~= "table" then return nil end
+        plain = GSE.EncodeMessage(obj)
+        GSEVariables[name] = plain
+    else
+        return nil
+    end
+    if GSE.ForgetDeltaFork then GSE.ForgetDeltaFork(obj) end
+    return plain
+end
+
 local function migrateSequenceVersions(sequence, sequenceName)
     if type(sequence) ~= "table" then return false end
     if sequence["Macros"] ~= nil and sequence.Versions == nil then
@@ -206,6 +234,7 @@ local function loadOneClass(classid)
                 local forked = GSE.ApplyStoredDeltaFork and GSE.ApplyStoredDeltaFork(GSE.Library[classid][i], j)
                 if forked then GSE.Library[classid][i] = forked end
                 GSE.AuditProtectedAtRest("sequence", classid, i, j, GSE.Library[classid][i])
+                GSE.HealOwnContentAtRest("sequence", classid, i, j, GSE.Library[classid][i])
                 local changed, reason = migrateSequenceVersions(GSE.Library[classid][i], i)
                 if reason == "macros-deprecated" then
                     -- Refuse to load. The on-disk record uses the old
@@ -265,6 +294,8 @@ function GSE.EnsureSequenceLoaded(classid, sequenceName)
                         GSESequences[classid][sequenceName])
                 if forked then GSE.Library[classid][sequenceName] = forked end
                 GSE.AuditProtectedAtRest("sequence", classid, sequenceName,
+                    GSESequences[classid][sequenceName], GSE.Library[classid][sequenceName])
+                GSE.HealOwnContentAtRest("sequence", classid, sequenceName,
                     GSESequences[classid][sequenceName], GSE.Library[classid][sequenceName])
                 local changed, reason = migrateSequenceVersions(GSE.Library[classid][sequenceName], sequenceName)
                 if reason == "macros-deprecated" then
@@ -698,6 +729,9 @@ function GSE.StoreEncodedSequence(name, encoded)
     local classid = GSE.GetClassIDforSpec(seq.MetaData and seq.MetaData.SpecID) or 0
     if GSE.isEmpty(GSESequences) then GSESequences = {} end
     if GSE.isEmpty(GSESequences[classid]) then GSESequences[classid] = {} end
+    -- The user's own content arrives packed like everything else the site
+    -- exports; store it plain unless the body itself says it is protected.
+    encoded = GSE.StorableForm(encoded, decoded, {name, seq})
     GSESequences[classid][name] = encoded
     -- Drop any stale decoded copy so the lazy loader re-decodes from the
     -- stored string (its canonical migrate + variable-load path).
@@ -715,6 +749,7 @@ function GSE.StoreEncodedVariable(name, encoded)
         return false
     end
     if GSE.isEmpty(GSEVariables) then GSEVariables = {} end
+    encoded = GSE.StorableForm(encoded, decoded, decoded)
     GSEVariables[name] = encoded
     if GSE.V then GSE.V[name] = nil end
     GSE:SendMessage(Statics.Messages.VARIABLE_UPDATED, name)
@@ -951,10 +986,15 @@ local function loadOneVariable(k, v)
         function()
             local localsuccess, uncompressedVersion = GSE.DecodeMessage(v)
             if not localsuccess then return end
-            -- This path never writes back -- which is why variables kept their
-            -- envelope where sequences lost it -- so there is nothing to gate,
-            -- only damage from an earlier build to report.
+            -- A variable edited while sealed keeps its edit in a delta fork,
+            -- the same as a sequence. Fold it in before anything reads the
+            -- body -- the heal below persists it, and the compile must see it.
+            local forked = GSE.ApplyStoredDeltaFork and GSE.ApplyStoredDeltaFork(uncompressedVersion, v)
+            if forked then uncompressedVersion = forked end
+            -- The audit only reports damage from an earlier build; the heal is
+            -- the one write this path makes, and only for the user's own content.
             GSE.AuditProtectedAtRest("variable", nil, k, v, uncompressedVersion)
+            GSE.HealOwnContentAtRest("variable", nil, k, v, uncompressedVersion)
             GSE.V[k] = gseLoadstring("return " .. uncompressedVersion.funct)()
             if type(GSE.V[k]()) == "boolean" then
                 GSE.BooleanVariables["GSE.V['" .. k .. "']()"] = "GSE.V['" .. k .. "']()"

--- a/GSE/API/Storage.lua
+++ b/GSE/API/Storage.lua
@@ -203,7 +203,7 @@ local function loadOneClass(classid)
                 -- A locally-edited copy lives in GSEDeltas; the stored blob is
                 -- only its base. Prefer the reconstruction or the edit is lost
                 -- the first time this class is loaded lazily.
-                local forked = GSE.ApplyStoredDeltaFork and GSE.ApplyStoredDeltaFork(GSE.Library[classid][i])
+                local forked = GSE.ApplyStoredDeltaFork and GSE.ApplyStoredDeltaFork(GSE.Library[classid][i], j)
                 if forked then GSE.Library[classid][i] = forked end
                 GSE.AuditProtectedAtRest("sequence", classid, i, j, GSE.Library[classid][i])
                 local changed, reason = migrateSequenceVersions(GSE.Library[classid][i], i)
@@ -261,7 +261,8 @@ function GSE.EnsureSequenceLoaded(classid, sequenceName)
             if localsuccess then
                 GSE.Library[classid][sequenceName] = uncompressedVersion[2]
                 local forked = GSE.ApplyStoredDeltaFork
-                    and GSE.ApplyStoredDeltaFork(GSE.Library[classid][sequenceName])
+                    and GSE.ApplyStoredDeltaFork(GSE.Library[classid][sequenceName],
+                        GSESequences[classid][sequenceName])
                 if forked then GSE.Library[classid][sequenceName] = forked end
                 GSE.AuditProtectedAtRest("sequence", classid, sequenceName,
                     GSESequences[classid][sequenceName], GSE.Library[classid][sequenceName])
@@ -311,6 +312,9 @@ end
 
 --- Remove a corrupt sequence from both compressed storage and the live library.
 function GSE.DeleteCorruptSequence(classid, name)
+    if GSE.ForgetDeltaFork and type(GSE.Library) == "table" and type(GSE.Library[classid]) == "table" then
+        GSE.ForgetDeltaFork(GSE.Library[classid][name])
+    end
     if type(GSESequences) == "table" and type(GSESequences[classid]) == "table" then
         GSESequences[classid][name] = nil
     end
@@ -333,6 +337,10 @@ function GSE.DeleteVariable(name)
     -- Companion sidecar: name ÃƒÆ’Ã†â€™Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â‚¬Å¡Ã‚Â¬Ãƒâ€šÃ‚Â ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â‚¬Å¡Ã‚Â¬ÃƒÂ¢Ã¢â‚¬Å¾Ã‚Â¢ server-id map. Clearing it stops the
     -- next sync from re-uploading the deleted variable on the basis of
     -- a stale stamp.
+    -- A variable can carry a fork for the same reason a sequence can.
+    if GSE.ForgetDeltaFork and GSEVariablePlatformIDs then
+        GSE.ForgetDeltaFork(GSEVariablePlatformIDs[name])
+    end
     if GSEVariablePlatformIDs then GSEVariablePlatformIDs[name] = nil end
 end
 
@@ -354,6 +362,11 @@ end
 
 --- Delete a sequence from the library
 function GSE.DeleteSequence(classid, sequenceName)
+    -- Read the id before the record goes, or there is nothing left to key by.
+    if GSE.ForgetDeltaFork then
+        GSE.ForgetDeltaFork(GSE.Library[tonumber(classid)]
+            and GSE.Library[tonumber(classid)][sequenceName])
+    end
     GSE.Library[tonumber(classid)][sequenceName] = nil
     GSESequences[tonumber(classid)][sequenceName] = nil
     GSE.ForgetCorruptSequence(classid, sequenceName)

--- a/GSE_GUI/Editor.lua
+++ b/GSE_GUI/Editor.lua
@@ -8149,7 +8149,7 @@ function GSE.GUILoadEditor(editor, key, recordedstring)
     -- reconstruction directly would make those edits land in whatever table the
     -- fork was rebuilt into, before the user has pressed anything.
     if sequence and GSE.ApplyStoredDeltaFork then
-        local forked = GSE.ApplyStoredDeltaFork(sequence)
+        local forked = GSE.ApplyStoredDeltaFork(sequence, GSESequences[classid][sequenceName])
         if forked then sequence = GSE.CloneSequence(forked) end
     end
 


### PR DESCRIPTION
Fixes #2074

Builds on #2075 -- it needs `GSE.ForgetDeltaFork` from there and touches the same load sites, so it is stacked rather than opened off master. Once #2075 merges this reduces to the single `db634bcc` commit.

The website seals every export it hands out, the owner's included -- once a
string is on the clipboard there is no way for the game to prove who pasted
it, so the site packs everything. That envelope says where the string came
from. It says nothing about what the content is; only the body does, via
MetaData.noExport.

ImportSerialisedSequence stores a packed string verbatim, and IsProtectedAtRest
then reads the envelope as proof of protection. So a user's own sequence,
exported from gse.tools and pasted into Import, was treated as protected from
that moment on: every save diverted into a delta fork, the record never written
plain, and the sequence only ever editable through fork machinery that exists
for content the user does not own.

Two parts.

GSE.StorableForm is the one rule: a packed blob whose body does not say
noExport is re-encoded plain, exactly as the addon would have written it
itself. Anything else -- protected, or not packed to begin with -- passes
through untouched. StoreEncodedSequence and StoreEncodedVariable apply it,
which covers a single paste, a collection import and the Companion-driven
paths alike.

GSE.HealOwnContentAtRest is the mirror of AuditProtectedAtRest, for content
already on disk: a blob still wearing the envelope whose body is not protected
is rewritten plain when its class loads. Any delta fork is applied FIRST -- the
sequence loaders already did that; the variable loader now does too, since it
never read a fork back at all -- so the user's edits fold into the record, and
the fork is then retired because a plain record saves in place from here on.

IsProtectedAtRest is unchanged, so genuinely protected content still cannot be
rewritten plain, and the audit still agrees: it only queues a repack when the
BODY says protected. Macros are deliberately left alone; they have a different
storage shape.

Tested offline with the functions sliced verbatim from the source: own content
unpacks and heals, protected content keeps its envelope, plain content passes
through, noExport=false is not protected, the heal encodes the fork-applied
object and retires the fork, and every guard returns nil without touching the
tables. Tested in game: the same export string that had landed sealed now lands
plain; an edit to it saves into the sequence with no fork created; and a
sequence that was sealed WITH a fork holding edits came out of the next load
plain, edits intact, fork gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
