### PR TITLE
Plugins: read a collection's members before judging it

### DIFF
--- a/GSE/API/Plugins.lua
+++ b/GSE/API/Plugins.lua
@@ -68,11 +68,66 @@ function GSE.LoadPluginSequences(sequencetable)
     GSE.PerformReloadSequences()
 end
 
---- Decode a single plugin sequence and return its compatibility status.
+--- Every sequence carried by one plugin entry, whatever shape it arrived in.
+--
+-- Three shapes reach here. A bare sequence has MetaData at the top. The
+-- on-disk form is the {name, sequence} tuple, so its MetaData is at [2]. And a
+-- plugin can ship a COLLECTION, which is {type = "COLLECTION", payload =
+-- {Sequences = {[name] = sequence}}} -- a wrapper with no MetaData of its own,
+-- because the version and the checksum belong to the sequences inside it.
+--
+-- Members are usually strings rather than tables, and a website export seals
+-- them, so most are !GSE3!+. Decode them anyway: GSE.DecodeMessage dispatches
+-- the packed envelope to DecodePackedMessage, and the addon HAS that key --
+-- being unable to read one is a Companion problem, not ours. Skipping them
+-- was what left a collection with nothing to judge and reported every
+-- sequence in it as "unknown".
+local function pluginSequenceMembers(decoded)
+    if type(decoded) ~= "table" then return {} end
+
+    if decoded.type == "COLLECTION" then
+        local out = {}
+        local payload = decoded.payload
+        local sequences = type(payload) == "table" and payload.Sequences or nil
+        if type(sequences) ~= "table" then return out end
+        for _, member in pairs(sequences) do
+            if type(member) == "table" then
+                out[#out + 1] = member
+            elseif type(member) == "string" then
+                local memberOk, memberDecoded = GSE.DecodeMessage(member)
+                -- A member can decode to the {name, sequence} tuple as well as
+                -- to the sequence itself.
+                if memberOk and type(memberDecoded) == "table" then
+                    if type(memberDecoded[2]) == "table" and type(memberDecoded[2].MetaData) == "table" then
+                        out[#out + 1] = memberDecoded[2]
+                    else
+                        out[#out + 1] = memberDecoded
+                    end
+                end
+            end
+        end
+        return out
+    end
+
+    -- {name, sequence}: the array form, metadata one level down.
+    if type(decoded[2]) == "table" and type(decoded[2].MetaData) == "table" then
+        return {decoded[2]}
+    end
+
+    if type(decoded.MetaData) == "table" then return {decoded} end
+    return {}
+end
+
+--- Decode a plugin entry and return its compatibility status.
 -- Returns a table:
 --   compatible  (bool)   - GSEVersion is in the valid range for this client
 --   GSEVersion  (number) - the sequence's GSEVersion, or nil if unreadable
 --   checksum    (string) - "valid", "invalid", or "no_checksum"
+--
+-- For a collection these describe every sequence in it together: compatible
+-- only when they all are, and the checksum is "invalid" if ANY member fails --
+-- one good sequence must not vouch for a bad one. GSEVersion reports the
+-- LOWEST found, since that is the one that decides compatibility.
 function GSE.GetPluginSequenceStatus(encodedSeq)
     local result = {compatible = false, GSEVersion = nil, checksum = "no_checksum"}
     if not encodedSeq then return result end
@@ -83,21 +138,49 @@ function GSE.GetPluginSequenceStatus(encodedSeq)
         ok, decoded = GSE.DecodeMessage(encodedSeq)
     end
     if not ok or not decoded then return result end
-    local meta = decoded.MetaData
-    if not meta then return result end
-    result.GSEVersion = meta.GSEVersion
-    result.compatible = meta.GSEVersion ~= nil
-        and meta.GSEVersion > 3200
-        and meta.GSEVersion <= GSE.VersionNumber
-    if result.compatible and GSE.VerifySequenceChecksum then
-        local cs = GSE.VerifySequenceChecksum(decoded)
-        if cs == true then
-            result.checksum = "valid"
-        elseif cs == false then
-            result.checksum = "invalid"
-        else
-            result.checksum = "no_checksum"
+
+    local members = pluginSequenceMembers(decoded)
+    if #members == 0 then return result end
+
+    local allCompatible = true
+    local anyInvalid, allValid = false, true
+    for _, sequence in ipairs(members) do
+        local meta = sequence.MetaData
+        local version = type(meta) == "table" and meta.GSEVersion or nil
+        if result.GSEVersion == nil or (version ~= nil and version < result.GSEVersion) then
+            result.GSEVersion = version
         end
+        -- Same rule the import path uses. OOCAddSequenceToCollection skips its
+        -- version gate entirely on a development build, because a source
+        -- checkout reports the hardcoded 3.3.00 from Init.lua and is by
+        -- definition ahead of whatever it last tagged -- so content built by a
+        -- newer GSE is not "incompatible" there, and must not read as such
+        -- here either. The addon migrates what it needs to on import.
+        local devBuild = type(GSE.VersionString) == "string"
+            and string.match(GSE.VersionString, "development") ~= nil
+        local compatible = version ~= nil
+            and version > 3200
+            and (devBuild or version <= GSE.VersionNumber)
+        if not compatible then allCompatible = false end
+
+        if compatible and GSE.VerifySequenceChecksum then
+            local cs = GSE.VerifySequenceChecksum(sequence)
+            if cs == false then
+                anyInvalid = true
+                allValid = false
+            elseif cs ~= true then
+                allValid = false
+            end
+        else
+            allValid = false
+        end
+    end
+
+    result.compatible = allCompatible
+    if anyInvalid then
+        result.checksum = "invalid"
+    elseif allValid then
+        result.checksum = "valid"
     end
     return result
 end


### PR DESCRIPTION
Fixes #2078

The plugin options panel reported "Not compatible with this version of GSE
(sequence version: unknown) / No checksum" for content that carries both.

GetPluginSequenceStatus only understood one shape: a bare sequence with
MetaData at the top. A plugin usually ships a COLLECTION -- {type =
"COLLECTION", payload = {Sequences = ...}} -- which has no MetaData of its own,
because the version and the checksum belong to the sequences inside it. The
function reached `if not meta then return result end` and returned the default,
which renders as unknown and unverified.

pluginSequenceMembers unwraps first. It handles the collection, the on-disk
{name, sequence} tuple whose metadata is one level down, and the bare sequence
as before. Members are usually strings, and a website export seals them, so
most are !GSE3!+ -- those are decoded rather than skipped: GSE.DecodeMessage
dispatches the packed envelope to DecodePackedMessage and the addon has that
key. Skipping them left a collection with nothing to judge, which was the
original symptom by another route.

For a collection the answers describe every member together: compatible only
when they all are, and the checksum is "invalid" if ANY member fails -- one
good sequence must not vouch for a bad one. GSEVersion reports the LOWEST
found, since that is the one that decides compatibility.

One more mismatch while here. The panel applied a stricter version rule than
the import path: OOCAddSequenceToCollection skips its version gate entirely on
a development build, because a source checkout reports the hardcoded 3.3.00
from Init.lua and is by definition ahead of whatever it last tagged. The panel
did not, so content built by a newer GSE read as incompatible while importing
and migrating it worked fine. It now uses the same rule; a release build keeps
the ceiling.

Nothing was ever gated on this -- status.compatible is read in one place, to
pick tooltip wording -- so this changes what the user is told, not what
installs.

Tested: 39 assertions over pluginSequenceMembers and GetPluginSequenceStatus
sliced verbatim from the source -- collection, tuple and bare shapes; sealed,
plain and undecodable members; every way a single bad member can hide behind a
good one; a development build accepting newer content while still rejecting
below the floor and still reporting a failed checksum; and a release build
unchanged. Confirmed in game against a plugin shipping a collection of sealed
sequences: reported unknown/no checksum before, reports the real version and a
valid checksum after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
