### PR TITLE
Let an unsealed record take its own edits back

### DIFF
--- a/GSE/API/Storage.lua
+++ b/GSE/API/Storage.lua
@@ -660,7 +660,14 @@ function GSE.ReplaceSequence(classid, sequenceName, sequence)
     GSE.StampOriginKey(sequence, sequenceName)
     GSE.ComputeSequenceDependencies(sequence)
     GSE.SnapshotDependentMacros(sequence)
-    if GSE.UpdateDeltaFork and GSE.UpdateDeltaFork(sequence) then
+    -- Asked ONCE, before the fork is consulted. A fork only exists because the
+    -- record was protected when the first edit landed, and it used to be read
+    -- first -- so a record that has since come back in the clear still had
+    -- every later edit swallowed by the fork it had outgrown. The owner then
+    -- sees local-changes controls on their own unsealed sequence, and no
+    -- amount of editing clears them, because each edit re-enters the fork.
+    local protectedAtRest = GSE.IsProtectedAtRest(GSESequences[classid][sequenceName], sequence)
+    if protectedAtRest and GSE.UpdateDeltaFork and GSE.UpdateDeltaFork(sequence) then
         GSE.Library[classid][sequenceName] = GSE.CloneSequence(sequence)
         GSE:SendMessage(Statics.Messages.SEQUENCE_UPDATED, sequenceName)
         return
@@ -670,7 +677,7 @@ function GSE.ReplaceSequence(classid, sequenceName, sequence)
     -- into the fork verbatim and only the divergence is written beside it.
     -- This branch is for protected content ONLY -- an ordinary sequence falls
     -- through to the plain replace below, exactly as before.
-    if GSE.IsProtectedAtRest(GSESequences[classid][sequenceName], sequence) then
+    if protectedAtRest then
         if not GSE.SeedDeltaFork(GSESequences[classid][sequenceName], sequence, "sequence") then
             -- Nothing to key a fork by, so the edit cannot be persisted here.
             -- Say so rather than writing it out in the clear.
@@ -680,6 +687,13 @@ function GSE.ReplaceSequence(classid, sequenceName, sequence)
         GSE:SendMessage(Statics.Messages.SEQUENCE_UPDATED, sequenceName)
         return
     end
+    -- Nothing left to protect, so the fork has nothing left to describe: this
+    -- write puts the edit -- which IS the reconstructed fork, the editor loads
+    -- through GSE.ApplyStoredDeltaFork -- into the record in the clear. The
+    -- same end-of-round-trip GSE.StoreEncodedSequence already handles when the
+    -- flattened copy arrives from the server; this is the local half of it.
+    -- Order matters: forget only once the plain write is about to happen.
+    if GSE.ForgetDeltaFork then GSE.ForgetDeltaFork(sequence) end
     -- Checksum is stamped on export only, not on save, so the stored checksum
     -- always reflects the last-exported state rather than the current edit state.
     GSESequences[classid][sequenceName] = GSE.EncodeMessage({sequenceName, sequence})

--- a/spec/packedatrest_spec.lua
+++ b/spec/packedatrest_spec.lua
@@ -139,6 +139,72 @@ describe(
             assert.equals(SEALED, _G.GSESequences[1]["Sealed"])
           end
         )
+
+        -- A fork exists only because the record was protected when the first
+        -- edit landed. The record can stop being protected afterwards -- the
+        -- owner's own work comes back from the server flattened and in the
+        -- clear -- and the fork then describes a divergence from a base that
+        -- is no longer there. Consulting it before asking about protection
+        -- meant every later edit was swallowed by a fork the record had
+        -- outgrown, so the owner saw local-changes controls on their own
+        -- unsealed sequence and no amount of editing cleared them.
+        describe(
+          "once the record is no longer protected",
+          function()
+            local forked, forgotten
+
+            before_each(
+              function()
+                forked, forgotten = false, false
+                GSE.UpdateDeltaFork = function() forked = true; return true end
+                GSE.ForgetDeltaFork = function() forgotten = true; return true end
+              end
+            )
+
+            after_each(
+              function()
+                GSE.UpdateDeltaFork = nil
+                GSE.ForgetDeltaFork = nil
+              end
+            )
+
+            it(
+              "writes the edit into the record instead of the fork",
+              function()
+                local seq = ownSeq("Mine")
+                _G.GSESequences[1]["Mine"] = "!GSE3!PLAINRECORD"
+                GSE.ReplaceSequence(1, "Mine", seq)
+                assert.is_false(forked)
+                assert.is_true(forgotten)
+                assert.are_not.equals("!GSE3!PLAINRECORD", _G.GSESequences[1]["Mine"])
+              end
+            )
+
+            it(
+              "still routes the edit to the fork while the blob is sealed",
+              function()
+                local seq = ownSeq("Sealed")
+                _G.GSESequences[1]["Sealed"] = SEALED
+                GSE.ReplaceSequence(1, "Sealed", seq)
+                assert.is_true(forked)
+                assert.is_false(forgotten)
+                assert.equals(SEALED, _G.GSESequences[1]["Sealed"])
+              end
+            )
+
+            it(
+              "still routes the edit to the fork while the body says noExport",
+              function()
+                local seq = protectedSeq("Prot")
+                _G.GSESequences[1]["Prot"] = "!GSE3!PLAINRECORD"
+                GSE.ReplaceSequence(1, "Prot", seq)
+                assert.is_true(forked)
+                assert.is_false(forgotten)
+                assert.equals("!GSE3!PLAINRECORD", _G.GSESequences[1]["Prot"])
+              end
+            )
+          end
+        )
       end
     )
 


### PR DESCRIPTION
Fixes #2082

`GSE.ReplaceSequence` asked the fork before it asked about protection. A fork
exists only because the record was protected when the first edit landed, and
the record can stop being protected afterwards -- the owner's own work comes
back from the server flattened and in the clear. Read first, the fork then
swallowed every later edit, so the owner saw the local-changes controls on
their own unsealed sequence and no amount of saving cleared them.

The question is asked once now, up front:

- **Sealed blob, or a `noExport` body** -- unchanged. The edit routes to the
  fork, the stored blob is left exactly as it is.
- **Neither** -- the plain write it was always entitled to, and the fork is
  dropped on the way past. That is the local half of the same
  end-of-round-trip `GSE.StoreEncodedSequence` already performs when the
  flattened copy arrives from the server, and `GSE.ForgetDeltaFork` already
  documents this case.

No ownership judgement is added. The addon is not deciding whose content this
is; it is writing an edit to a record that carries nothing to protect, which
is what every ordinary sequence already does.

Nothing is lost when the fork goes: the sequence being written IS the
reconstructed fork, since every load path reaches it through
`GSE.ApplyStoredDeltaFork`.

### Verified

Three cases added to `spec/packedatrest_spec.lua` -- edit lands in the record
once it is unprotected, and still routes to the fork for a sealed blob and for
a `noExport` body.

Run end to end on a live install against two real sequences in this state.
Before: fork content newer than the record, controls stuck on. After a save
and a reload: `GSEDeltas` empty, both records now `LastUpdated 20260910220735`
and `20260910220739` -- the edits that were in the forks -- `PlatformID`,
`Author` and `OriginKey` intact, controls gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
