### PR TITLE
Loop block: Step FN and Repeat share one row

### DIFF
--- a/GSE_GUI/Editor.lua
+++ b/GSE_GUI/Editor.lua
@@ -5964,7 +5964,12 @@ function GSE.CreateEditor()
                 local stepRow = UI:Create("SimpleGroup")
                 stepRow:SetLayout("Flow")
                 stepRow:SetFullWidth(true)
-                stepRow:SetHeight(24)
+                -- STYLE.flowPadY above and below the tallest child, which is
+                -- the 26px Repeat box. A row set to the child's own height has
+                -- nowhere to put that padding: layoutFlow still starts the
+                -- child flowPadY down, so it overhangs the bottom edge and the
+                -- block border closes up right under it.
+                stepRow:SetHeight(36)
                 if stepRow.SetFlowGap then stepRow:SetFlowGap(6) end
                 if stepRow.SetFlowVAlign then stepRow:SetFlowVAlign("CENTER") end
                 if stepRow.SetFlowOffset then stepRow:SetFlowOffset(7, 0) end
@@ -5976,24 +5981,22 @@ function GSE.CreateEditor()
                 if stepRowLabel.SetJustifyV then stepRowLabel:SetJustifyV("MIDDLE") end
                 stepRow:AddChild(stepRowLabel)
                 stepRow:AddChild(stepdropdown)
-                layout3:AddChild(stepRow)
-
-                local repeatRow = UI:Create("SimpleGroup")
-                repeatRow:SetLayout("Flow")
-                repeatRow:SetFullWidth(true)
-                repeatRow:SetHeight(26)
-                if repeatRow.SetFlowGap then repeatRow:SetFlowGap(6) end
-                if repeatRow.SetFlowVAlign then repeatRow:SetFlowVAlign("CENTER") end
-                if repeatRow.SetFlowOffset then repeatRow:SetFlowOffset(7, 0) end
+                -- Repeat rides on the step row rather than a row of its own.
+                -- Two one-control rows cost a whole line of block height each
+                -- and the pair reads as one setting anyway: how the block
+                -- steps, and how many times.
                 local repeatRowLabel = UI:Create("Label")
                 repeatRowLabel:SetText(L["Repeat"])
-                repeatRowLabel:SetWidth(loopControlLabelWidth)
+                -- Its own width, not loopControlLabelWidth: 82 is the leading
+                -- column that lines the block's labels up down the left edge,
+                -- and a second one that wide pushes the box off the row.
+                repeatRowLabel:SetWidth(46)
                 repeatRowLabel:SetHeight(24)
                 repeatRowLabel:SetColor(keywordColor())
                 if repeatRowLabel.SetJustifyV then repeatRowLabel:SetJustifyV("MIDDLE") end
-                repeatRow:AddChild(repeatRowLabel)
-                repeatRow:AddChild(looplimit)
-                layout3:AddChild(repeatRow)
+                stepRow:AddChild(repeatRowLabel)
+                stepRow:AddChild(looplimit)
+                layout3:AddChild(stepRow)
 
                 local macroGroup = UI:Create("SimpleGroup")
                 macroGroup:SetFullWidth(true)


### PR DESCRIPTION
Fixes #2084

```
Step FN  [Priority          v]   Repeat [2]
```

Repeat had a row to itself for one four-character box, so every Loop block in
a sequence spent a whole line of height on it.

Two details worth calling out:

- Repeat's label takes its own width rather than `loopControlLabelWidth`. That
  82 is the leading column that lines the block's labels up down the left
  edge; a second one that wide pushes the box off the end of the row.
- The row is 36, not the tallest child's 26. `layoutFlow` already lays
  children out `STYLE.flowPadY` down from the top, so a row set to exactly the
  child's height has nowhere to put that padding -- the box overhung the
  bottom edge and the block border closed up right underneath it. 5 + 26 + 5,
  and `FlowVAlign CENTER` puts them in the middle of the band.

The controls themselves are untouched -- same widgets, same callbacks, same
tooltips. Only which row they are added to, and that row's height.

### Verified

Run in the live editor on a Loop block: both controls on one row, centred,
with the block border no longer flush against the number box. No wrap at the
editor's minimum width -- 7 offset + 82 + 150 + 46 + 30 plus gaps is 337px in
a full-width block. `luac -p` clean, no undeclared globals.

The issue also asks for the same layout on GSE.Tools so the website and the
in-game editor match; that half is not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
