### PR TITLE
Character macros: stop deleting their buckets, and sync into them

### DIFF
--- a/GSE/API/Storage.lua
+++ b/GSE/API/Storage.lua
@@ -3319,8 +3319,16 @@ function GSE.ManageMacros()
             }
             GSE.UpdateMacro(node)
         else
+            -- GetMacroIndexByName answers 0, not nil, for a name this character
+            -- does not have -- and 0 is truthy. Tested as `if slot`, every miss
+            -- went to GetMacroInfo(0), came back nil, and was deleted. That
+            -- includes the character buckets themselves: this loop walks every
+            -- key in GSEMacros, "Name-Realm" is never a macro name, so each
+            -- bucket was dropped the moment it was created. The else branch
+            -- below, which keeps tables, was written for exactly this case and
+            -- could never be reached.
             local slot = GetMacroIndexByName(k)
-            if slot then
+            if slot and slot > 0 then
                 local mname, micon, mbody = GetMacroInfo(slot)
                 if mname then
                     GSEMacros[mname] = {
@@ -3370,8 +3378,10 @@ function GSE.ManageMacros()
                     }
                     GSE.UpdateMacro(node)
                 else
+                    -- 0 on a miss, as above: a macro this bucket holds that the
+                    -- character does not is kept, not deleted.
                     local slot = GetMacroIndexByName(k)
-                    if slot then
+                    if slot and slot > 0 then
                         local mname, micon, mbody = GetMacroInfo(slot)
                         if mname then
                             GSEMacros[char .. "-" .. realm][mname] = {

--- a/GSE_Utils/MacroSync.lua
+++ b/GSE_Utils/MacroSync.lua
@@ -19,72 +19,100 @@ local Statics = GSE.Static
 
 local MAX_GLOBAL_MACROS = GSE.GetMaxAccountMacros() or 120
 
--- Names of macros this module has added to GSEMacros. Used to detect deletions
--- without accidentally removing Companion-installed macros that may not exist
--- locally on this character.
-local syncTrackedNames = {}
+-- Names of macros this module has added to GSEMacros, per store. Used to
+-- detect deletions without accidentally removing Companion-installed macros
+-- that may not exist locally on this character.
+local syncTrackedNames = { account = {}, character = {} }
 
 --- Capture the current state of all WoW macros on this character.
--- Returns { [name] = { body, icon, character } }
+-- Returns two tables, account and character, each { [name] = { body, icon, slot } }.
+-- Two tables, not one keyed by name: an account macro and a character macro
+-- can share a name, and one table let the character copy overwrite the other.
 local function captureWoWMacros()
-    if not GetNumMacros then return {} end
-    local t = {}
+    if not GetNumMacros then return {}, {} end
+    local account, character = {}, {}
     local numGlobal, numChar = GetNumMacros()
     for i = 1, numGlobal do
         local name, icon, body = GetMacroInfo(i)
         if name and name ~= "" then
-            t[name] = { body = body or "", icon = icon, character = false }
+            account[name] = { body = body or "", icon = icon, slot = i }
         end
     end
     for i = 1, (numChar or 0) do
         local name, icon, body = GetMacroInfo(MAX_GLOBAL_MACROS + i)
         if name and name ~= "" then
-            t[name] = { body = body or "", icon = icon, character = true }
+            character[name] = { body = body or "", icon = icon, slot = MAX_GLOBAL_MACROS + i }
         end
     end
-    return t
+    return account, character
 end
 
---- Diff current WoW macros against GSEMacros and apply additions, updates,
--- and removals for macros this module is tracking.
-function GSE.SyncWoWMacrosToGSE()
-    if not GSEOptions.SyncWoWMacros then return end
-    if GSE.isEmpty(GSEMacros) then GSEMacros = {} end
+--- The GSEMacros bucket holding this character's macros. Same key, and the
+-- same realm fallback, GSE.ManageMacros reads them back from.
+local function characterBucket()
+    local char, realm = UnitFullName("player")
+    if GSE.isEmpty(realm) then
+        realm = string.gsub(GetRealmName(), "%s*", "")
+    end
+    local key = char .. "-" .. realm
+    if type(GSEMacros[key]) ~= "table" then GSEMacros[key] = {} end
+    return GSEMacros[key]
+end
 
-    local current = captureWoWMacros()
-
-    -- Add / update: any WoW macro whose body differs from what we have stored
+--- Reflect one set of WoW macros into one GSEMacros store.
+--
+-- The entry carries `text`. GSE.ManageMacros, GSE.UpdateMacro and the
+-- Companion all read the body from `text`; the Companion goes further and
+-- treats any entry WITHOUT a string `text` as a character bucket, so an entry
+-- holding only `manageMacro` had its own fields read back as macros.
+local function syncInto(store, current, tracked)
     for name, data in pairs(current) do
-        syncTrackedNames[name] = true
-        local stored = GSEMacros[name]
+        tracked[name] = true
+        local stored = store[name]
         local storedBody = ""
         if type(stored) == "table" then
             storedBody = stored.manageMacro or stored.text or ""
         end
         if storedBody ~= data.body then
-            GSEMacros[name] = {
+            store[name] = {
                 name        = name,
                 icon        = data.icon,
-                value       = GetMacroIndexByName(name),
+                value       = data.slot,
+                text        = data.body,
                 manageMacro = data.body,
             }
         end
     end
 
     -- Remove: tracked macros that have been deleted from WoW
-    for name in pairs(syncTrackedNames) do
+    for name in pairs(tracked) do
         if not current[name] then
-            GSEMacros[name] = nil
-            syncTrackedNames[name] = nil
+            store[name] = nil
+            tracked[name] = nil
         end
     end
+end
+
+--- Diff current WoW macros against GSEMacros and apply additions, updates,
+-- and removals for macros this module is tracking.
+--
+-- Character macros go to the character's bucket, never to account level. At
+-- account level they uploaded without category "p", and came back down
+-- through GSE.ImportMacro into General Macros on every character.
+function GSE.SyncWoWMacrosToGSE()
+    if not GSEOptions.SyncWoWMacros then return end
+    if GSE.isEmpty(GSEMacros) then GSEMacros = {} end
+
+    local account, character = captureWoWMacros()
+    syncInto(GSEMacros, account, syncTrackedNames.account)
+    syncInto(characterBucket(), character, syncTrackedNames.character)
 end
 
 --- Perform a full initial import of all WoW macros (called on enable or login).
 function GSE.SyncAllWoWMacros()
     if not GSEOptions.SyncWoWMacros then return end
     -- Reset tracking so we correctly manage any macros from a previous session.
-    syncTrackedNames = {}
+    syncTrackedNames = { account = {}, character = {} }
     GSE.SyncWoWMacrosToGSE()
     local numGlobal, numChar = GetNumMacros()
     GSE.Print(


### PR DESCRIPTION
Fixes #2086

Two faults, one symptom: character-specific macros never reached GSEMacros
under their character, so the Companion never uploaded them as character
macros.

### `GSE.ManageMacros` -- stop deleting the buckets

`GetMacroIndexByName` answers 0 on a miss, and 0 is truthy. The account-level
loop walks every key in `GSEMacros`, buckets included, so every
`"Name-Realm"` bucket went to `GetMacroInfo(0)`, came back nil, and was
deleted. Both `if slot then` tests are now `if slot and slot > 0 then` -- the
form `UpdateMacro` and `SnapshotDependentMacros` already use -- which lets the
existing keep-the-table branch do the job it was written for.

### `GSE.SyncWoWMacrosToGSE` -- write character macros into their bucket

- Character macros go to `GSEMacros["Name-Realm"]`, keyed with the same
  `UnitFullName` + stripped-`GetRealmName` fallback `ManageMacros` reads them
  back with.
- Account and character macros are captured into separate tables. They can
  share a name, and one table let the character copy overwrite the account
  one.
- Every entry carries `text`. The Companion treats any entry without a string
  `text` as a bucket, so an entry holding only `manageMacro` had its own
  fields read back as macros.
- Deletion tracking is per store, so removing a character macro in WoW never
  touches the account level.

### Verified

The real `GSE.ManageMacros` and the real MacroSync functions, sliced out of
source and run against a fake macro book where `GetMacroIndexByName` answers 0
on a miss: 14/14 checks pass; against the code on master, 11 of them fail.

End to end on a live install: `/reload`, enable Sync WoW Macros, `/reload`.
`GSEMacros["Kavchak-Thrall"]` is on disk with 11 macros -- the same 11 names
WoW's own `macros-cache.txt` holds for that character -- every one with a
string `text`, none duplicated at account level, and the 50 account macros
unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
