### PR TITLE
Editor: deleting the last block leaves one Action block

### DIFF
--- a/GSE_GUI/Editor.lua
+++ b/GSE_GUI/Editor.lua
@@ -4459,6 +4459,23 @@ function GSE.CreateEditor()
                         if targetList and delObj and delObj >= 1 and delObj <= #targetList then
                             table.remove(targetList, delObj)
                             removed = true
+                            -- A sequence always keeps one block. Deleting the last
+                            -- one used to leave Actions empty with the selection still
+                            -- pointing at the block just removed, and the next Add
+                            -- walked that stale path into nothing and errored. Put
+                            -- back the same single Action a new sequence starts with;
+                            -- the refocus below then selects it as {1}.
+                            if #delPath == 0 and #targetList == 0 then
+                                table.insert(targetList, {
+                                    ["macro"] = "Need Stuff Here",
+                                    ["type"] = "macro",
+                                    ["Type"] = Statics.Actions.Action
+                                })
+                                -- From the top: the saved scroll position belongs to
+                                -- the list that just emptied, and the rebuild restores
+                                -- it (finishDraw and ChooseVersion both SetScroll it).
+                                editframe.scrollStatus.scrollvalue = 0
+                            end
                         end
 
                         -- Deleting a block used to leave the rebuilt editor scrolled to the


### PR DESCRIPTION
Fixes #2088

Deleting the last top-level block now puts back the same single Action block
a new sequence starts with. The delete handler's existing refocus then selects
it as `{1}`, which also replaces the stale selection that made the next Add
error. The editor starts at the top: the saved scroll position belonged to the
list that just emptied, and `finishDraw` / `ChooseVersion` restore it.

Unchanged: emptying a nested list (a Loop) still leaves it empty and focuses
the parent, and deleting any other block keeps the scroll position.

### Verified

- The real delete handler, sliced from source and run against a model
  sequence: 9/9 checks pass, and the 4 for this case fail on master.
- In game: delete down to the last block and delete it, and one "Need Stuff
  Here" block remains, selected, at the top. Add Block then works with no
  error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
