### PR TITLE
Sequences with missing metadata no longer blank the list or stop a reload

### DIFF
--- a/GSE/API/Storage.lua
+++ b/GSE/API/Storage.lua
@@ -1426,14 +1426,22 @@ function GSE.PerformReloadSequences(force)
         end
         func = GSE.UpdateSequence
     end
+    -- A record with no MetaData or no Versions -- one the editor's tree flags
+    -- as corrupt -- has nothing in it to compile, and reading either field off
+    -- it stopped the reload for every sequence after it. Anything else is
+    -- compiled exactly as before: a missing SpecID, say, still runs.
+    local function reloadable(sequence)
+        return type(sequence) == "table" and type(sequence.MetaData) == "table"
+            and type(sequence.Versions) == "table"
+    end
     for name, sequence in pairs(GSE.Library[GSE.GetCurrentClassID()]) do
-        if not sequence.MetaData.Disabled then
+        if reloadable(sequence) and not sequence.MetaData.Disabled then
             func(name, sequence.Versions[GSE.GetActiveSequenceVersion(name)])
         end
     end
     if not GSE.isEmpty(GSE.Library[0]) then
         for name, sequence in pairs(GSE.Library[0]) do
-            if GSE.isEmpty(sequence.MetaData.Disabled) then
+            if reloadable(sequence) and GSE.isEmpty(sequence.MetaData.Disabled) then
                 func(name, sequence.Versions[GSE.GetActiveSequenceVersion(name)])
             end
         end
@@ -1638,6 +1646,15 @@ function GSE.GetSequenceNames(Library)
         GSEOptions.filterList[Statics.Global] = true
     end
     local currentClassID = GSE.GetCurrentClassID()
+    -- A record with no MetaData or no SpecID still gets a key -- spec 0, the
+    -- key a not-yet-decoded foreign-class sequence already gets below --
+    -- rather than throwing. This runs before the tree isolates each sequence,
+    -- so one such record blanked the whole list, New Sequence and Import
+    -- included; the tree now lists it and flags it red for deletion.
+    local function specOf(j)
+        local meta = type(j) == "table" and j.MetaData
+        return (type(meta) == "table" and meta.SpecID) or 0
+    end
     local keyset = {}
     for k, _ in pairs(Library) do
         if GSEOptions.filterList[Statics.All] or k == currentClassID then
@@ -1645,14 +1662,14 @@ function GSE.GetSequenceNames(Library)
                 -- Library already loaded for these classes ÃƒÆ’Ã†â€™Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡Ãƒâ€šÃ‚Â¬ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â‚¬Å¡Ã‚Â¬Ãƒâ€šÃ‚Â full metadata available.
                 for i, j in pairs(Library[k]) do
                     local disable = 0
-                    if j.DisableEditor then
+                    if type(j) == "table" and j.DisableEditor then
                         disable = 1
                     end
-                    local keyLabel = k .. "," .. j.MetaData.SpecID .. "," .. i .. "," .. disable
+                    local keyLabel = k .. "," .. specOf(j) .. "," .. i .. "," .. disable
                     if k == currentClassID and GSEOptions.filterList["Class"] then
                         keyset[keyLabel] = i
                     elseif k == currentClassID and not GSEOptions.filterList["Class"] then
-                        if j.MetaData.SpecID == GSE.GetCurrentSpecID() or j.MetaData.SpecID == currentClassID then
+                        if specOf(j) == GSE.GetCurrentSpecID() or specOf(j) == currentClassID then
                             keyset[keyLabel] = i
                         end
                     else
@@ -1672,10 +1689,10 @@ function GSE.GetSequenceNames(Library)
             if k == 0 and GSEOptions.filterList[Statics.Global] then
                 for i, j in pairs(Library[k]) do
                     local disable = 0
-                    if j.DisableEditor then
+                    if type(j) == "table" and j.DisableEditor then
                         disable = 1
                     end
-                    local keyLabel = k .. "," .. j.MetaData.SpecID .. "," .. i .. "," .. disable
+                    local keyLabel = k .. "," .. specOf(j) .. "," .. i .. "," .. disable
                     keyset[keyLabel] = i
                 end
             end
@@ -2325,7 +2342,10 @@ function GSE.GetSequenceSummary()
     for k, v in ipairs(GSE.Library) do
         returntable[k] = {}
         for i, j in pairs(v) do
-            if not (j["MetaData"] and j["MetaData"].noExport) then
+            -- No MetaData, no summary. `not (MetaData and noExport)` is true
+            -- when MetaData is missing, so a record the tree flags as corrupt
+            -- went on to read .Help off nil. Healthy records are unchanged.
+            if type(j) == "table" and type(j["MetaData"]) == "table" and not j["MetaData"].noExport then
                 returntable[k][i] = {}
                 returntable[k][i].Help = j["MetaData"].Help
                 returntable[k][i].LastUpdated = j["MetaData"].LastUpdated

--- a/GSE_GUI/Editor_Tree.lua
+++ b/GSE_GUI/Editor_Tree.lua
@@ -1534,10 +1534,15 @@ local function ManageTree(editframe)
         local tnode = {}
         if k > 0 then
             local classinfo, classfile = GetClassInfo(k)
-            local text =
-                C_ClassColor and
-                WrapTextInColorCode(classinfo, C_ClassColor.GetClassColor(classfile):GenerateHexColor()) or
-                classinfo
+            -- A class this client does not have -- a Demon Hunter or Evoker
+            -- sequence on a Classic client, or a bad class id -- has no info and
+            -- no colour. :GenerateHexColor() on that nil threw after every
+            -- sequence was built and before SetTree, so the list came up blank.
+            local color = classfile and C_ClassColor and C_ClassColor.GetClassColor(classfile)
+            local text = classinfo or ("Class " .. tostring(k))
+            if color and classinfo then
+                text = WrapTextInColorCode(classinfo, color:GenerateHexColor())
+            end
             tnode = {
                 value = k,
                 text = text,


### PR DESCRIPTION
Fixes #2089

Four places read `MetaData` off every Library entry unguarded. Each now
tolerates a malformed record, and healthy records take exactly the same path as
before:

| Where | Before | Now |
|---|---|---|
| `GetSequenceNames` | `j.MetaData.SpecID` threw, so the list was blank | keys it under spec 0, like a not-yet-decoded foreign-class sequence; the tree flags it red |
| `ManageTree` class node | `GetClassColor(nil):GenerateHexColor()` threw, so the list was blank | plain `Class N` label for a class the client does not know |
| `PerformReloadSequences` | `sequence.MetaData.Disabled` threw, so no sequence reloaded | skips a record with no MetaData or no Versions table; everything else compiles as before, missing SpecID included |
| `GetSequenceSummary` | `not (nil and ...)` fell through to `.Help` on nil | leaves it out; healthy and `noExport` records unchanged |

The rest of the Library loops were checked and already guard `MetaData`: the
icon hydration that runs at login, the dependency walks, the keybind check,
`Events.lua`'s migration and `Storage.lua:3035`.

### Verified

- Each function sliced from source and run against a Library containing a
  healthy record, one with no MetaData, one with no SpecID, and a class the
  client does not know. All checks pass, and every one fails on master with the
  crash reported in #2089.
- In game: a record with no MetaData and one with no SpecID, injected into the
  current class, blanked the list on master; with this change the list builds,
  both flagged red. The `Storage.lua:1430` reload crash was hit on master through
  `/gse checksequencesforerrors` and no longer occurs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
