### PR TITLE
Editor: remember the last opened sequence per class

### DIFF
--- a/GSE_GUI/Editor.lua
+++ b/GSE_GUI/Editor.lua
@@ -8266,7 +8266,11 @@ function GSE.ShowSequences()
         local parts = {("\001"):split(lastSequencePath)}
         local pathClass = parts[2] and tostring(parts[2]) or ""
         if pathClass ~= classID and not (showingGlobal and tonumber(pathClass) == 0) then
-            lastSequencePath = nil   -- wrong class, fall back to current class
+            -- Not a class this tree shows. Fall back to the last sequence opened
+            -- on THIS class, so each character lands where it left off instead
+            -- of on New Sequence -- and never on another class's sequence.
+            lastSequencePath = GSE.GUI.GetLastSequenceEditorPathForClass
+                and GSE.GUI.GetLastSequenceEditorPathForClass(tonumber(classID)) or nil
         end
     end
 

--- a/GSE_GUI/Editor_Tree.lua
+++ b/GSE_GUI/Editor_Tree.lua
@@ -504,7 +504,19 @@ end
 local function SaveLastSequenceEditorPath(group, unique)
     if unique[1] ~= "Sequences" or #unique < 4 or unique[#unique] == "newversion" then return end
     local opts = GetSequenceEditorOptions()
-    if opts then opts.lastSequencePath = group end
+    if not opts then return end
+    opts.lastSequencePath = group
+    -- Remembered per class as well. The single path above belongs to whichever
+    -- class was used last, and the editor drops it when this character's tree
+    -- cannot show it -- so logging in on another character landed on New
+    -- Sequence. Kept per class, each one comes back to where it left off, and a
+    -- Shaman's sequence is never opened on a Demon Hunter.
+    local elements = GSE.split(unique[3] or "", ",")
+    local pathClass = tonumber(elements[1])
+    if pathClass then
+        opts.lastSequencePathByClass = opts.lastSequencePathByClass or {}
+        opts.lastSequencePathByClass[pathClass] = group
+    end
 end
 
 function GSE.GUI.GetLastSequenceEditorPath()
@@ -533,10 +545,24 @@ end
 -- so forgetting means clearing all four. Called from PLAYER_LOGOUT when
 -- GSEOptions.forgetLastSequenceOnLogout is set; the state is still kept during
 -- the session, so only the next login sees a fresh editor.
+--- The last sequence opened on `classid`, or nil. Asked when the most recent
+--- sequence belongs to a class this character's tree cannot show.
+function GSE.GUI.GetLastSequenceEditorPathForClass(classid)
+    classid = tonumber(classid)
+    local opts = GetSequenceEditorOptions()
+    local byClass = opts and opts.lastSequencePathByClass
+    if not (classid and byClass) then return nil end
+    local path = byClass[classid]
+    if SequenceEditorPathExists(path) then return path end
+    byClass[classid] = nil
+    return nil
+end
+
 function GSE.GUI.ForgetLastSequenceEditorNode()
     local opts = GetSequenceEditorOptions()
     if not opts then return end
     opts.lastSequencePath = nil
+    opts.lastSequencePathByClass = nil
     opts.lastArea = nil
     opts.lastKey = nil
     opts.lastClassId = nil

--- a/GSE_GUI/Editor_Tree.lua
+++ b/GSE_GUI/Editor_Tree.lua
@@ -538,13 +538,6 @@ function GSE.GUI.GetLastSequenceEditorPath()
     return nil
 end
 
--- Drop everything the editor remembers about where the user last was: the
--- sequence path used by GSE.ShowSequences, and the area/key/classid trio
--- RestoreLastNode uses for the Variables, Macros and Keybindings tabs. Both
--- live in the same saved-variable table and are written as you click around,
--- so forgetting means clearing all four. Called from PLAYER_LOGOUT when
--- GSEOptions.forgetLastSequenceOnLogout is set; the state is still kept during
--- the session, so only the next login sees a fresh editor.
 --- The last sequence opened on `classid`, or nil. Asked when the most recent
 --- sequence belongs to a class this character's tree cannot show.
 function GSE.GUI.GetLastSequenceEditorPathForClass(classid)
@@ -558,6 +551,15 @@ function GSE.GUI.GetLastSequenceEditorPathForClass(classid)
     return nil
 end
 
+-- Drop everything the editor remembers about where the user last was: the
+-- sequence path used by GSE.ShowSequences, the per-class paths behind it, and
+-- the area/key/classid trio RestoreLastNode uses for the Variables, Macros and
+-- Keybindings tabs. They all live in the same saved-variable table and are
+-- written as you click around, so forgetting means clearing every one of them
+-- -- leaving the per-class table behind would reopen on the next login exactly
+-- what the option asked to forget. Called from PLAYER_LOGOUT when
+-- GSEOptions.forgetLastSequenceOnLogout is set; the state is still kept during
+-- the session, so only the next login sees a fresh editor.
 function GSE.GUI.ForgetLastSequenceEditorNode()
     local opts = GetSequenceEditorOptions()
     if not opts then return end


### PR DESCRIPTION
Fixes #2095

`SaveLastSequenceEditorPath` now also records the path under its class, and
`GSE.GUI.GetLastSequenceEditorPathForClass(classid)` reads it back. When the
most recent path belongs to a class this character's tree does not show, the
editor falls back to the last sequence opened on THIS class instead of giving
up and opening New Sequence.

Unchanged:

- The most recent path still wins whenever the tree can show it, including a
  Global sequence while the Global filter is on.
- The existing single path is still written, so nothing that reads it changes,
  and a player upgrading keeps the sequence they had.
- A remembered sequence that has since been deleted is dropped rather than
  restored -- the per-class lookup runs the same `SequenceEditorPathExists`
  check and clears the stale entry.
- "Forget Last Opened Sequence on Logout" clears the per-class memory too.

Another class's sequence is never opened for you: the fallback only ever
returns a path recorded for the class you are on.

### Verified

- `SaveLastSequenceEditorPath` and `GetLastSequenceEditorPathForClass`, sliced
  from source and run with two classes' paths saved side by side: each class
  gets its own back, a Demon Hunter never gets the Shaman's, a class with
  nothing recorded returns nil, and a deleted sequence returns nil and clears
  its entry. 9/9.
- In game across a logout: opened a sequence on one character, logged into a
  character of another class and got that class's own last sequence, then
  logged back and got the first one again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
