### PR TITLE
Editor: sort the class, Variables and Macros lists alphabetically

### DIFF
--- a/GSE_GUI/Editor_Macro.lua
+++ b/GSE_GUI/Editor_Macro.lua
@@ -134,6 +134,15 @@ local function buildMacroMenu()
             end
         end
     end
+
+    -- Alphabetical within each group. The loop above walks WoW's macro slots,
+    -- which is creation order, and a node's value is its slot id -- so sorting
+    -- what is displayed leaves what each node points at alone.
+    local function byName(a, b)
+        return GSE.AlphabeticalTableSortAlgorithm(a.text or "", b.text or "")
+    end
+    table.sort(tree.children[1].children, byName)
+    table.sort(tree.children[2].children, byName)
     return tree
 end
 

--- a/GSE_GUI/Editor_Tree.lua
+++ b/GSE_GUI/Editor_Tree.lua
@@ -1780,6 +1780,8 @@ local function ManageTree(editframe)
                 icon = GSE.GetClassIcon(k),
                 children = {}
             }
+            -- Sorted on the plain name: `text` is wrapped in the class colour.
+            tnode.gseSortName = classinfo or ("Class " .. tostring(k))
         elseif k == 0 then
             -- value is the classid, 0, NOT the string "GLOBAL" it used to be.
             -- Node values are what AceGUI concatenates into a node's path, and
@@ -1793,6 +1795,7 @@ local function ManageTree(editframe)
                 text = L["Global"],
                 children = {}
             }
+            tnode.gseSortName = L["Global"]
         end
         for _, j in pairs(v) do
             for _, h in ipairs(j) do
@@ -1801,6 +1804,15 @@ local function ManageTree(editframe)
         end
         table.insert(subtree.children, tnode)
     end
+
+    -- Classes in alphabetical order rather than class-id order, with Global
+    -- last: it is not a class, and it reads as the catch-all at the end rather
+    -- than sitting between Evoker and Hunter.
+    table.sort(subtree.children, function(a, b)
+        if a.value == 0 then return false end
+        if b.value == 0 then return true end
+        return GSE.AlphabeticalTableSortAlgorithm(a.gseSortName or "", b.gseSortName or "")
+    end)
 
     table.insert(tree, subtree)
     table.insert(tree, editframe.buildKeybindMenu())

--- a/GSE_GUI/Editor_Variable.lua
+++ b/GSE_GUI/Editor_Variable.lua
@@ -56,7 +56,9 @@ local function buildVariablesMenu()
             }
         }
     }
-    for k, _ in pairs(GSEVariables or {}) do
+    -- Alphabetical, the same order and the same comparison the sequence tree
+    -- uses. pairs() gave hash order, so the list shuffled between sessions.
+    for k, _ in GSE.pairsByKeys(GSEVariables or {}, GSE.AlphabeticalTableSortAlgorithm) do
         local node = {
             value = k,
             text = "|CFFFFFFFF" .. k .. Statics.StringReset


### PR DESCRIPTION
Fixes #2099

All three lists now sort with `GSE.AlphabeticalTableSortAlgorithm`, the
comparison the sequence list already uses, so the whole tree agrees on what
alphabetical means.

- **Classes** sort on the plain class name, not `text`, which is wrapped in the
  class colour. Global is pinned last: it is not a class, and it reads as the
  catch-all at the end. Each node keeps its class id, so paths, expansion and
  selection are untouched.
- **Variables** iterate through `GSE.pairsByKeys` rather than `pairs`.
- **Macros** are sorted within each group, Account and Character, after the
  slot walk. A node's value is still its macro slot, so sorting what is
  displayed leaves what each node opens alone.

### Verified

Run against the real builders, sliced from source with deliberately unordered
input:

- classes come out `Death Knight, Druid, Evoker, Paladin, Warrior, Global`;
- variables `Mike, alpha, bravo, zulu`;
- macros `Alpha, mid, zeta` (account) and `charlie, yankee` (character), with
  each node still pointing at its own slot.

The existing tree checks still pass, so class colours and the unknown-class
fallback are unaffected. In game: all three lists in order, and expanding,
selecting and opening still work.

Note the comparison is case-sensitive, so capitalised names sort before
lowercase ones -- the same as the sequence list does today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
