### PR TITLE
Plugins: let an addon apply a sequence it wrote into GSE's store

### DIFF
--- a/GSE/API/Plugins.lua
+++ b/GSE/API/Plugins.lua
@@ -210,6 +210,10 @@ local publicProxy = {
     -- Sequences table before handing it to RegisterAddon. Without it the
     -- registration handshake errors before it reaches the two methods above.
     isEmpty = GSE.isEmpty,
+    -- For an addon that writes a sequence or variable into GSE's store itself:
+    -- have GSE re-read it and rebuild, instead of waiting for a reload.
+    ApplyStoredSequence = GSE.ApplyStoredSequence,
+    ApplyStoredVariable = GSE.ApplyStoredVariable,
     Statics = {}
 }
 setmetatable(publicProxy, {

--- a/GSE/API/Storage.lua
+++ b/GSE/API/Storage.lua
@@ -746,6 +746,77 @@ function GSE.StoreEncodedSequence(name, encoded)
     return true
 end
 
+--- For an addon that writes a sequence into GSESequences itself: re-read that
+--- one sequence from the store and rebuild its button, rather than leave the
+--- change unseen until the next reload.
+--
+-- GSE decodes the store into its in-memory Library at load and compiles the
+-- buttons from that copy, and nothing watches GSESequences afterwards -- so a
+-- write from outside GSE reached disk at once and the running game only at the
+-- next /reload. /gse recompilesequences does not help: it recompiles from the
+-- same stale in-memory copy.
+--
+-- `classid` is optional; without it the sequence is looked for in the current
+-- class, then Global, then any other. The rebuild goes through the OOC queue,
+-- so in combat it lands as combat ends. A sequence of a class this character is
+-- not is re-read but not built, the same as at load.
+--
+-- Returns true when the sequence was found and re-read.
+function GSE.ApplyStoredSequence(sequenceName, classid)
+    if type(sequenceName) ~= "string" or type(GSESequences) ~= "table" then return false end
+    classid = tonumber(classid)
+    if not (classid and type(GSESequences[classid]) == "table" and GSESequences[classid][sequenceName]) then
+        classid = nil
+        local current = GSE.GetCurrentClassID()
+        for _, cid in ipairs({current, 0}) do
+            if type(GSESequences[cid]) == "table" and GSESequences[cid][sequenceName] then
+                classid = cid
+                break
+            end
+        end
+        if not classid then
+            for cid, store in pairs(GSESequences) do
+                if type(store) == "table" and store[sequenceName] then
+                    classid = cid
+                    break
+                end
+            end
+        end
+    end
+    if not classid then return false end
+
+    -- Drop the stale decoded copy so the loader re-reads the store.
+    if type(GSE.Library[classid]) == "table" then GSE.Library[classid][sequenceName] = nil end
+    GSE.EnsureSequenceLoaded(classid, sequenceName)
+    local sequence = GSE.Library[classid] and GSE.Library[classid][sequenceName]
+    if type(sequence) ~= "table" then return false end
+
+    if (classid == GSE.GetCurrentClassID() or classid == 0) and type(sequence.Versions) == "table" then
+        local version = GSE.GetActiveSequenceVersion(sequenceName)
+        if version and sequence.Versions[version] then
+            GSE.UpdateSequence(sequenceName, sequence.Versions[version])
+        end
+    end
+    -- Marks this update as one that came from the store, so an editor showing
+    -- the sequence reloads it instead of only reporting it is behind.
+    GSE.ApplyingStoredSequence = sequenceName
+    GSE:SendMessage(Statics.Messages.SEQUENCE_UPDATED, sequenceName)
+    GSE.ApplyingStoredSequence = nil
+    return true
+end
+
+--- The same for a variable an addon writes into GSEVariables itself. GSE.V
+--- reloads any missing entry from the store on its next use, so clearing the
+--- compiled copy is all it takes -- the same thing StoreEncodedVariable does.
+function GSE.ApplyStoredVariable(name)
+    if type(name) ~= "string" or type(GSEVariables) ~= "table" or GSE.isEmpty(GSEVariables[name]) then
+        return false
+    end
+    if GSE.V then GSE.V[name] = nil end
+    GSE:SendMessage(Statics.Messages.VARIABLE_UPDATED, name)
+    return true
+end
+
 function GSE.StoreEncodedVariable(name, encoded)
     if type(name) ~= "string" or type(encoded) ~= "string" then return false end
     local ok, decoded = GSE.DecodeMessage(encoded)

--- a/GSE_GUI/Editor.lua
+++ b/GSE_GUI/Editor.lua
@@ -8160,6 +8160,24 @@ function GSE.CreateEditor()
                         editframe:SetStatusText(editframe.statusText or ("GSE: " .. GSE.VersionString))
                     end
                 )
+            elseif GSE.ApplyingStoredSequence == seqName then
+                -- Written into GSE's store by another addon and applied live
+                -- (GSE.ApplyStoredSequence). Reload this view from the store the
+                -- way clicking back onto the sequence does, instead of leaving
+                -- it showing the old blocks. Anything edited here and not saved
+                -- is replaced; the addon that wrote it owns the sequence.
+                local tree = editframe.treeContainer
+                local status = tree and (tree.status or tree.localstatus)
+                local selected = status and status.selected
+                if selected then
+                    -- The click path re-reads the store only when this differs.
+                    editframe.OrigSequenceName = nil
+                    C_Timer.After(0, function()
+                        if editframe.SequenceName == seqName and GSE.GUI.SelectEditorTreePath then
+                            GSE.GUI.SelectEditorTreePath(editframe, selected)
+                        end
+                    end)
+                end
             else
                 editframe:SetStatusText(
                     seqName .. " " .. L["modified in other window.  This view is now behind the current sequence."]


### PR DESCRIPTION
Fixes #2102

Two additions to the public proxy, for addons that write GSE's store directly,
plus a live refresh in the editor. Nothing existing changes behaviour.

### `GSE.ApplyStoredSequence(name, classid)` -- Storage.lua

1. Finds the sequence in `GSESequences`: in `classid` if it is given and holds
   it; otherwise in the current class, then Global, then any other.
2. Drops the decoded Library copy and re-reads it with `EnsureSequenceLoaded`,
   so delta forks, migration and variable loading all run exactly as on a
   lazy load.
3. For the current class or Global, queues `GSE.UpdateSequence` with
   `GetActiveSequenceVersion`, so the rebuild goes through the OOC queue and
   waits out combat or an encounter as usual. Another class's sequence is
   re-read but not built, the same as at load.
4. Sends `SEQUENCE_UPDATED`, returns true when the sequence was found and
   re-read.

### `GSE.ApplyStoredVariable(name)` -- Storage.lua

Clears the compiled `GSE.V` entry and sends `VARIABLE_UPDATED`. `GSE.V`'s
existing `__index` reloads a missing entry from `GSEVariables` on next use, so
this mirrors what `StoreEncodedVariable` already does.

### Proxy -- Plugins.lua

Both functions are added to `publicProxy` alongside `RegisterAddon`, with a
comment on what they are for.

### Editor -- Editor.lua

`ApplyStoredSequence` sets `GSE.ApplyingStoredSequence` around its
`SEQUENCE_UPDATED`. When `remoteSequenceUpdated` sees that for the open
sequence, it clears `OrigSequenceName` and re-selects the current tree node on
the next frame. That is the same path a click back onto the sequence takes, so
the view re-reads the store and redraws on the page the player was on. Any
other remote update -- another GSE window saving -- keeps the existing "this
view is now behind" message and leaves the view alone.

Trade-off: unsaved edits made in GSE's editor to a sequence that another addon
then applies are replaced. The addon writing it owns that sequence, and the
editor has no unsaved-change tracking to test against (`GSE.GUI.ResetUndo` is
called but not defined anywhere).

### Verified

- `ApplyStoredSequence` and `ApplyStoredVariable` sliced from source and run
  against a model store (9/9):
  - a current-class sequence's stale copy is replaced and its rebuild queued
    with the active version;
  - another class's sequence is re-read with no rebuild;
  - a wrong `classid` still finds a Global sequence;
  - unknown names return false;
  - a variable's compiled copy is cleared.
- `remoteSequenceUpdated` sliced from source (5/5): an update from the store
  re-selects the current node and forces the re-read with no "behind" message;
  any other update leaves the view alone and still reports it is behind.
- In game with SLG-SBAssist calling both after each write: block changes reach
  the sequence button without a reload, and an open editor on that sequence
  updates on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
